### PR TITLE
Fixes bug with int points instead of double for objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [next]
 
-## 0.5.0+1
+## 0.5.1
 * Fixes bug with int points instead of double for objects.
 
 ## 0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [next]
 
+## 0.5.0+1
+* Fixes bug with int points instead of double for objects.
+
 ## 0.5.0
 
 * Fixes bug with inconsistent indexes crashes for rectangular maps.

--- a/lib/src/tile_map_parser.dart
+++ b/lib/src/tile_map_parser.dart
@@ -97,7 +97,7 @@ class TileMapParser {
     final points = node.getAttribute('points').split(' ');
     return points.map((point) {
       final arr = point.split(',');
-      final p = (str) => int.parse(str);
+      final p = (str) => double.parse(str);
       return Point(p(arr.first), p(arr.last));
     }).toList();
   }

--- a/lib/src/tmx_object.dart
+++ b/lib/src/tmx_object.dart
@@ -4,11 +4,11 @@ class TmxObject {
   String name;
   String type;
 
-  int x;
-  int y;
-  int width = 0;
-  int height = 0;
-  int rotation = 0;
+  double x;
+  double y;
+  double width = 0;
+  double height = 0;
+  double rotation = 0;
   int gid;
   bool visible = true;
 
@@ -28,11 +28,11 @@ class TmxObject {
     NodeDSL.on(element, (dsl) {
       name = dsl.strOr('name', name);
       type = dsl.strOr('type', type);
-      x = dsl.intOr('x', x);
-      y = dsl.intOr('y', y);
-      width = dsl.intOr('width', width);
-      height = dsl.intOr('height', height);
-      rotation = dsl.intOr('rotation', rotation);
+      x = dsl.doubleOr('x', x);
+      y = dsl.doubleOr('y', y);
+      width = dsl.doubleOr('width', width);
+      height = dsl.doubleOr('height', height);
+      rotation = dsl.doubleOr('rotation', rotation);
       gid = dsl.intOr('gid', gid);
       visible = dsl.boolOr('visible', visible);
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: tiled
-version: 0.5.0
+version: 0.5.1
 description: A Dart Tiled library. Parse your TMX files into useful representations. Compatible with Flame.
 homepage: https://github.com/flame-engine/tiled.dart
 


### PR DESCRIPTION
There is a bug in the current implementation of the `TmxObject`. 

The `x`, `y`, `width`, `height`, `rotation` and `points` properties of an object in Tiled are not integer based but double based. So if you place an object not exactly on an integer the parser wont be able to parse the values properly and it throws an exception.

By switching to the double parser instead of the integer parser for these properties we can load the tiled map again.

So not only does this PR solve a bug, it also allows us to have more fine tuned positioning of the objects.