### PR TITLE
Fixed parseTmx for CSV-formatted tilemap layers

### DIFF
--- a/lib/src/layer.dart
+++ b/lib/src/layer.dart
@@ -274,7 +274,14 @@ abstract class Layer {
     }
 
     if (encoding == FileEncoding.csv) {
-      return (data as List).cast<int>();
+      if (data is List) {
+        return data.cast<int>();
+      } else {
+        // csv data must be parsed
+        return List.from(
+          (data as String).split(',').map<int>((s) => int.parse(s.trim())),
+        );
+      }
     }
     // Ok, its base64
     final trim = data.toString().replaceAll('\n', '').trim();

--- a/test/fixtures/test_csv.tmx
+++ b/test/fixtures/test_csv.tmx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1">
+ <tileset firstgid="1" name="basketball" tilewidth="32" tileheight="32" tilecount="2" columns="1">
+  <properties>
+   <property name="test_property" value="test_value"/>
+  </properties>
+  <image source="icons.png" width="32" height="32"/>
+  <tile id="0">
+   <properties>
+    <property name="tile_0_property_name" value="tile_0_property_value"/>
+   </properties>
+  </tile>
+  <tile id="1">
+   <properties>
+    <property name="tile_1_property_name" value="tile_1_property_value"/>
+   </properties>
+  </tile>
+ </tileset>
+ <layer id="1" name="Tile Layer 1" width="10" height="10">
+  <data encoding="csv">
+1,0,0,0,0,0,0,0,0,0,
+0,1,0,0,0,0,0,0,0,0,
+0,0,1,0,0,0,0,0,0,0,
+0,0,0,1,0,0,0,0,0,0,
+0,0,0,0,1,0,0,0,0,0,
+0,0,0,0,0,1,0,0,0,0,
+0,0,0,0,0,0,1,0,0,0,
+0,0,0,0,0,0,0,1,0,0,
+0,0,0,0,0,0,0,0,1,0,
+0,0,0,0,0,0,0,0,0,1
+</data>
+ </layer>
+</map>

--- a/test/parser_compare_test.dart
+++ b/test/parser_compare_test.dart
@@ -41,6 +41,13 @@ void main() {
     });
   });
 
+  late TiledMap tileMapCsv;
+  setUp(() {
+    return File('./test/fixtures/test_csv.tmx').readAsString().then((xml) {
+      tileMapCsv = TileMapParser.parseTmx(xml);
+    });
+  });
+
   late TiledMap tileMap;
   setUp(() {
     return File('./test/fixtures/test.tmx').readAsString().then((xml) {
@@ -97,6 +104,10 @@ void main() {
     test(
       'toString should be equal',
       () => expect(map4.type, equals(tileMap.type)),
+    );
+    test(
+      'toString should be equal',
+      () => expect(tileMapCsv.type, equals(tileMap.type)),
     );
 
     test(


### PR DESCRIPTION
This pull request fixes parsing of tilemaps formatted in .tmx with layer data encoding set to CSV. It's actually kind of surprising this issue wasn't addressed before because AFAIK this is Tiled's default configuration.

When parsing a layer, its data was assumed to be a list. This already works well for JSON tilemaps. I added support to convert the CSV `String` into a `List<int>`.

This commit also includes a test for this encoding which would fail and throw a `TypeError` before.