### PR TITLE
Fixed crash on empty tile terrain entries

### DIFF
--- a/lib/src/tileset/tile.dart
+++ b/lib/src/tileset/tile.dart
@@ -24,7 +24,7 @@ class Tile {
   double probability;
 
   /// List of indexes of the terrain.
-  List<int> terrain;
+  List<int?> terrain;
 
   TiledImage? image;
   Layer? objectGroup;
@@ -52,7 +52,7 @@ class Tile {
       terrain: parser
               .getStringOrNull('terrain')
               ?.split(',')
-              .map(int.parse)
+              .map(int.tryParse)
               .toList() ??
           [],
       image: parser.getSingleChildOrNullAs('image', TiledImage.parse),


### PR DESCRIPTION
Empty entries in a tile's terrain list are supported by Tiled. A tile with terrain crashes on trying to parse an empty string to an int. Swapping to tryParse and a nullable int list fixes the crash.