### PR TITLE
Fixed: First tile in an external tileset was always empty

### DIFF
--- a/lib/src/tiled_map.dart
+++ b/lib/src/tiled_map.dart
@@ -139,7 +139,7 @@ class TiledMap {
   // Convenience Methods
   Tile tileByGid(int tileGid) {
     if (tileGid == 0) {
-      return Tile(localId: 0);
+      return Tile(localId: -1);
     }
     final tileset = tilesetByTileGId(tileGid);
     final firstGid = tileset.firstGid ?? 0;

--- a/lib/src/tileset/tile.dart
+++ b/lib/src/tileset/tile.dart
@@ -42,7 +42,7 @@ class Tile {
     this.properties = const [],
   });
 
-  bool get isEmpty => localId == 0;
+  bool get isEmpty => localId == -1;
 
   static Tile parse(Parser parser) {
     return Tile(

--- a/lib/src/tileset/tileset.dart
+++ b/lib/src/tileset/tileset.dart
@@ -94,9 +94,7 @@ class Tileset {
     this.transparentColor,
     this.type = TilesetType.tileset,
   }) : tiles = _generateTiles(tiles, tileCount ?? 0) {
-    if (tileCount == null && tiles.isNotEmpty) {
-      tileCount = tiles.last.localId;
-    }
+    tileCount ??= tiles.length;
   }
 
   static Tileset parse(Parser parser, {TsxProvider? tsx}) {
@@ -220,7 +218,7 @@ class Tileset {
     final tiles = <Tile>[];
     final iterator = explicitTiles.iterator;
     var t = iterator.moveNext() ? iterator.current : Tile(localId: -1);
-    for (var i = 0; i <= tileCount; ++i) {
+    for (var i = 0; i < tileCount; ++i) {
       if (t.localId == i) {
         tiles.add(t);
         if (iterator.moveNext()) {

--- a/lib/src/tileset/tileset.dart
+++ b/lib/src/tileset/tileset.dart
@@ -94,7 +94,7 @@ class Tileset {
     this.transparentColor,
     this.type = TilesetType.tileset,
   }) : tiles = _generateTiles(tiles, tileCount ?? 0) {
-    tileCount ??= tiles.length;
+    tileCount = this.tiles.length;
   }
 
   static Tileset parse(Parser parser, {TsxProvider? tsx}) {
@@ -216,16 +216,15 @@ class Tileset {
 
   static List<Tile> _generateTiles(List<Tile> explicitTiles, int tileCount) {
     final tiles = <Tile>[];
-    final iterator = explicitTiles.iterator;
-    var t = iterator.moveNext() ? iterator.current : Tile(localId: -1);
-    for (var i = 0; i < tileCount; ++i) {
-      if (t.localId == i) {
-        tiles.add(t);
-        if (iterator.moveNext()) {
-          t = iterator.current;
-        }
+    for (var i = 0; i < tileCount; i += 1) {
+      tiles.add(Tile(localId: i));
+    }
+
+    for (final tile in explicitTiles) {
+      if (tile.localId >= tiles.length) {
+        tiles.add(tile);
       } else {
-        tiles.add(Tile(localId: i));
+        tiles[tile.localId] = tile;
       }
     }
     return tiles;

--- a/test/fixtures/external_tileset_map.tmx
+++ b/test/fixtures/external_tileset_map.tmx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.8" tiledversion="1.8.90" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="1">
+ <tileset firstgid="1" source="tileid_over_tilecount.tsx"/>
+ <layer id="2" name="layer1" width="5" height="5">
+  <data encoding="csv">
+65,55,56,57,65,
+65,95,53,54,65,
+65,60,52,58,65,
+130,60,52,58,65,
+68,67,11,129,10
+</data>
+ </layer>
+</map>

--- a/test/fixtures/tileid_over_tilecount.tsx
+++ b/test/fixtures/tileid_over_tilecount.tsx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tileset version="1.8" tiledversion="1.8.90" name="external" tilewidth="16" tileheight="16" tilecount="136" columns="17">
+ <image source="level1.png" width="272" height="128"/>
+ <tile id="0" type="first_tile"/>
+ <tile id="136">
+  <properties>
+   <property name="type" value="expands_tilecount"/>
+  </properties>
+ </tile>
+</tileset>

--- a/test/map_test.dart
+++ b/test/map_test.dart
@@ -88,8 +88,8 @@ void main() {
       );
     });
 
-    test('raises an ArgumentError if tileset is not present', () {
-      expect(map.tileByGid(0).localId, equals(0));
+    test('there should be no tile with a Gid of 0', () {
+      expect(map.tileByGid(0).localId, equals(-1));
     });
 
     group('returns a tile', () {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -222,6 +222,23 @@ void main() {
     });
   });
 
+  group('External tileset tile parsing', () {
+    test('it parsed the first tile', () {
+      return File('./test/fixtures/external_tileset_map.tmx')
+          .readAsString()
+          .then((xml) {
+        final map = TileMapParser.parseTmx(
+          xml,
+          tsxList: [CustomTsxProvider.parse('tileid_over_tilecount.tsx')],
+        );
+        expect(map.tilesets[0].tileCount, 137);
+        final tile = map.tileByGid(1);
+        expect(tile.localId, 0);
+        expect(tile.type, 'first_tile');
+      });
+    });
+  });
+
   group('Parser.parse with tsx provider', () {
     test('it loads external tsx', () {
       return File('./test/fixtures/map_images.tmx').readAsString().then((xml) {
@@ -275,48 +292,48 @@ void main() {
     test(
       'correct number of tilests',
       () => expect(
-        map.tilesets.length == 3,
-        true,
+        map.tilesets.length,
+        3,
       ),
     );
 
     test('tilesets firstgid correct', () {
       expect(
-        map.tilesets.first.firstGid == 1,
-        true,
+        map.tilesets.first.firstGid,
+        1,
       );
 
       expect(
-        map.tilesets.last.firstGid == 273,
-        true,
+        map.tilesets.last.firstGid,
+        273,
       );
     });
     test('first tileset details correct', () {
       expect(
-        map.tilesets.first.name == 'level1',
-        true,
+        map.tilesets.first.name,
+        'level1',
       );
 
       expect(
-        map.tilesets.first.tileCount == 136,
-        true,
+        map.tilesets.first.tileCount,
+        136,
       );
     });
     test('embedded tileset details correct', () {
       expect(
-        map.tilesets[1].name == 'level_embed',
-        true,
+        map.tilesets[1].name,
+        'level_embed',
       );
     });
     test('third tileset details correct', () {
       expect(
-        map.tilesets.last.name == 'level2',
-        true,
+        map.tilesets.last.name,
+        'level2',
       );
 
       expect(
-        map.tilesets.last.tileCount == 288,
-        true,
+        map.tilesets.last.tileCount,
+        288,
       );
     });
   });

--- a/test/tile_test.dart
+++ b/test/tile_test.dart
@@ -3,26 +3,26 @@ import 'package:tiled/tiled.dart';
 
 void main() {
   group('Tile.emptyTile()', () {
-    test('creates a tile with GID = 0', () {
-      final tile = Tile(localId: 0);
-      expect(tile.localId, equals(0));
+    test('creates a tile with GID = -1', () {
+      final tile = Tile(localId: -1);
+      expect(tile.localId, equals(-1));
     });
   });
 
   group('Tile.isEmpty', () {
-    test('returns true if gid == 0', () {
-      final tile = Tile(localId: 0);
+    test('returns true if gid == -1', () {
+      final tile = Tile(localId: -1);
       expect(tile.isEmpty, isTrue);
     });
 
-    test('returns false if gid != 0', () {
-      final tile = Tile(localId: 0)..localId = 1;
+    test('returns false if gid != -1', () {
+      final tile = Tile(localId: -1)..localId = 0;
       expect(tile.isEmpty, isFalse);
     });
   });
 
   test('Tile.properties is present', () {
-    final tile = Tile(localId: 0);
+    final tile = Tile(localId: -1);
     expect(tile.properties, isA<List>());
   });
 }


### PR DESCRIPTION
Simplified tile creation, fixing an issue where the first tile in an external tileset was always empty. This blocked a access to the desired first tile using TiledMap.tileByGid(). Since the tile list is definitely filled with every tile, we can just use its length rather than the last tile's localId.