### PR TITLE
Add class_ getter for type

### DIFF
--- a/lib/src/objects/tiled_object.dart
+++ b/lib/src/objects/tiled_object.dart
@@ -10,6 +10,8 @@ part of tiled;
 ///   Can not be changed in Tiled. (since Tiled 0.11)
 /// * name: The name of the object. An arbitrary string. (defaults to “”)
 /// * type: The type of the object. An arbitrary string. (defaults to “”)
+/// * class_: The class of the object. An arbitrary string. (defaults to “”).
+///           It replaces "type" property starting 1.9.
 /// * x: The x coordinate of the object in pixels. (defaults to 0)
 /// * y: The y coordinate of the object in pixels. (defaults to 0)
 /// * width: The width of the object in pixels. (defaults to 0)
@@ -65,6 +67,10 @@ class TiledObject {
   List<Point> polyline;
   List<Property> properties;
 
+  // The "Class" property, a.k.a "Type" prior to Tiled 1.9.
+  /// Will be same as [type].
+  String get class_ => type;
+
   TiledObject({
     required this.id,
     this.name = '',
@@ -102,7 +108,13 @@ class TiledObject {
     final id = parser.getInt('id');
     final gid = parser.getIntOrNull('gid');
     final name = parser.getString('name', defaults: '');
-    final type = parser.getString('type', defaults: '');
+
+    // Tiled 1.9 and above versions running in compatibilty mode set to "Tiled 1.8" will
+    // still write out "Class" property as "type". So try both before using default value.
+    final type = parser.getString(
+      'class',
+      defaults: parser.getString('type', defaults: ''),
+    );
 
     final ellipse = parser.formatSpecificParsing(
       (json) => json.getBool('ellipse'),

--- a/test/tmx_object_test.dart
+++ b/test/tmx_object_test.dart
@@ -25,8 +25,9 @@ void main() {
         expect(tiledObject.name, equals('Circle'));
       });
 
-      test('sets type to "circle"', () {
+      test('sets type and class to "circle"', () {
         expect(tiledObject.type, equals('circle'));
+        expect(tiledObject.class_, equals('circle'));
       });
 
       test('sets x to 344', () {
@@ -62,8 +63,9 @@ void main() {
         expect(tiledObject.name, equals('Rectangle'));
       });
 
-      test('sets type to "rectangle"', () {
+      test('sets type and class to "rectangle"', () {
         expect(tiledObject.type, equals('rectangle'));
+        expect(tiledObject.class_, equals('rectangle'));
       });
 
       test('sets x to 541', () {
@@ -95,8 +97,9 @@ void main() {
         expect(tiledObject.name, equals('Polygon'));
       });
 
-      test('sets type to "polygon"', () {
+      test('sets type and class to "polygon"', () {
         expect(tiledObject.type, equals('polygon'));
+        expect(tiledObject.class_, equals('polygon'));
       });
 
       test('sets x to 752', () {


### PR DESCRIPTION
Since Tiled 1.9, the `Type` property for objects has been changed to `Class` by default. This PR modifies the parsing logic to first look for `class` and then `type` before using the default (empty string) value. We need to look for both keys because Tiled has also provided a compatibility option in project properties using which, users can force Tiled to write out `Class` property as `type` in exported files. I've also added a getter called `class_` which returns `type` so that it will be easier for users to find this property.

Details about this change is mentioned in Tiled 1.9 release notes under section "Unified Custom Types" : https://www.mapeditor.org/2022/06/25/tiled-1-9-released.html