### PR TITLE
Making `tile.type` compatible with Tiled 1.9's new Unified Custom Typ…

### DIFF
--- a/lib/src/tileset/tile.dart
+++ b/lib/src/tileset/tile.dart
@@ -47,7 +47,7 @@ class Tile {
   static Tile parse(Parser parser) {
     return Tile(
       localId: parser.getInt('id'),
-      type: parser.getStringOrNull('type'),
+      type: parser.getStringOrNull('type') ?? parser.getStringOrNull('class'), /// Tiled 1.9 "type" has been moved to "class"
       probability: parser.getDouble('probability', defaults: 0),
       terrain: parser
               .getStringOrNull('terrain')


### PR DESCRIPTION
…es ("class")

https://www.mapeditor.org/2022/06/25/tiled-1-9-released.html

New in tiled 1.9:
```xml
  <tile id="98" class="Slope">
   <properties>
    <property name="LeftTop" type="int" value="0"/>
    <property name="RightTop" type="int" value="8"/>
   </properties>
  </tile>
```

Previously:
```xml
  <tile id="98" type="Slope">
   <properties>
    <property name="LeftTop" type="int" value="0"/>
    <property name="RightTop" type="int" value="8"/>
   </properties>
  </tile>
```