### PR TITLE
Add parser support for Tiled hex colors as ui.Color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.8.5
+## [Next]
 * Add parser support for Tiled hex colors as `ui.Color`
+* BREAKING CHANGE: re-named string color fields to `colorHex` such as `layer.tintColorHex` and 
+  added a new `color` field paired with each `colorHex` field of type `ui.Color`.
 
 ## 0.8.4
 * Adding "class" attribute for Tiled 1.9's Unified Custom Types:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.5
+* Add parser support for Tiled hex colors as `ui.Color`
+
 ## 0.8.4
 * Adding "class" attribute for Tiled 1.9's Unified Custom Types:
     * On `Tile` accessible as `class_` or `type`, backwards compatible with "type" property 

--- a/lib/src/layer.dart
+++ b/lib/src/layer.dart
@@ -77,6 +77,10 @@ abstract class Layer {
   /// any graphics drawn by this layer or any child layers (optional).
   String? tintColor;
 
+  /// Parsed [Color] that is multiplied with
+  /// any graphics drawn by this layer or any child layers (optional).
+  Color? tintColor_;
+
   /// The opacity of the layer as a value from 0 to 1. Defaults to 1.
   double opacity;
 
@@ -100,6 +104,7 @@ abstract class Layer {
     this.startX,
     this.startY,
     this.tintColor,
+    this.tintColor_,
     this.opacity = 1,
     this.visible = true,
     this.properties = const [],
@@ -123,6 +128,7 @@ abstract class Layer {
     final startX = parser.getIntOrNull('startx');
     final startY = parser.getIntOrNull('starty');
     final tintColor = parser.getStringOrNull('tintcolor');
+    final tintColor_ = parser.getColorOrNull('tintcolor');
     final opacity = parser.getDouble('opacity', defaults: 1);
     final visible = parser.getBool('visible', defaults: true);
     final properties = parser.getProperties();
@@ -160,6 +166,7 @@ abstract class Layer {
           startX: startX,
           startY: startY,
           tintColor: tintColor,
+          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
@@ -176,7 +183,10 @@ abstract class Layer {
           'draworder',
           defaults: DrawOrder.topDown,
         );
-        final color = parser.getString('color', defaults: '#a0a0a4');
+        final color =
+            parser.getString('color', defaults: ObjectGroup.defaultColorHex);
+        final color_ =
+            parser.getColor('color', defaults: ObjectGroup.defaultColor);
         final objects = parser.getChildrenAs('object', TiledObject.parse);
         layer = ObjectGroup(
           id: id,
@@ -191,16 +201,19 @@ abstract class Layer {
           startX: startX,
           startY: startY,
           tintColor: tintColor,
+          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
           drawOrder: drawOrder,
           objects: objects,
           color: color,
+          color_: color_,
         );
         break;
       case LayerType.imageLayer:
         final transparentColor = parser.getStringOrNull('transparentcolor');
+        final transparentColor_ = parser.getColorOrNull('transparentcolor');
         final image = parser.getSingleChildAs('image', TiledImage.parse);
         final repeatX = parser.getBool('repeatx', defaults: false);
         final repeatY = parser.getBool('repeaty', defaults: false);
@@ -219,11 +232,13 @@ abstract class Layer {
           startX: startX,
           startY: startY,
           tintColor: tintColor,
+          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
           image: image,
           transparentColor: transparentColor,
+          transparentColor_: transparentColor_,
         );
         break;
       case LayerType.group:
@@ -241,6 +256,7 @@ abstract class Layer {
           startX: startX,
           startY: startY,
           tintColor: tintColor,
+          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
@@ -375,6 +391,7 @@ class TileLayer extends Layer {
     int? startX,
     int? startY,
     String? tintColor,
+    Color? tintColor_,
     double opacity = 1,
     bool visible = true,
     List<Property> properties = const [],
@@ -399,10 +416,12 @@ class TileLayer extends Layer {
           startX: startX,
           startY: startY,
           tintColor: tintColor,
+          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
         );
+
   static List<List<Gid>>? maybeGenerate(
     List<int>? data,
     int width,
@@ -416,6 +435,9 @@ class TileLayer extends Layer {
 }
 
 class ObjectGroup extends Layer {
+  static const defaultColor = Color.fromARGB(255, 160, 160, 164);
+  static const defaultColorHex = '%a0a0a4';
+
   /// topdown (default) or index (indexOrder).
   DrawOrder drawOrder;
 
@@ -425,6 +447,10 @@ class ObjectGroup extends Layer {
   /// The color used to display the objects in this group.
   /// (defaults to gray (“#a0a0a4”))
   String color;
+
+  /// The [Color] used to display the objects in this group.
+  /// (defaults to gray (“#a0a0a4”))
+  Color color_;
 
   ObjectGroup({
     int? id,
@@ -439,12 +465,14 @@ class ObjectGroup extends Layer {
     int? startX,
     int? startY,
     String? tintColor,
+    Color? tintColor_,
     double opacity = 1,
     bool visible = true,
     List<Property> properties = const [],
     this.drawOrder = DrawOrder.topDown,
     required this.objects,
-    this.color = '#a0a0a4',
+    this.color = defaultColorHex,
+    this.color_ = defaultColor,
   }) : super(
           id: id,
           name: name,
@@ -459,6 +487,7 @@ class ObjectGroup extends Layer {
           startX: startX,
           startY: startY,
           tintColor: tintColor,
+          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
@@ -469,8 +498,11 @@ class ImageLayer extends Layer {
   /// Image used by this layer.
   TiledImage image;
 
-  /// Hex-formatted color (#RRGGBB) (optional).
+  /// Hex-formatted color (#RRGGBB) to be rendered as transparent (optional).
   String? transparentColor;
+
+  /// [Color] to be rendered as transparent (optional).
+  Color? transparentColor_;
 
   /// Whether or not to repeat the image on the X-axis
   bool repeatX;
@@ -491,6 +523,7 @@ class ImageLayer extends Layer {
     int? startX,
     int? startY,
     String? tintColor,
+    Color? tintColor_,
     double opacity = 1,
     bool visible = true,
     List<Property> properties = const [],
@@ -498,6 +531,7 @@ class ImageLayer extends Layer {
     required this.repeatX,
     required this.repeatY,
     this.transparentColor,
+    this.transparentColor_,
   }) : super(
           id: id,
           name: name,
@@ -512,6 +546,7 @@ class ImageLayer extends Layer {
           startX: startX,
           startY: startY,
           tintColor: tintColor,
+          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
@@ -535,6 +570,7 @@ class Group extends Layer {
     int? startX,
     int? startY,
     String? tintColor,
+    Color? tintColor_,
     double opacity = 1,
     bool visible = true,
     List<Property> properties = const [],
@@ -553,6 +589,7 @@ class Group extends Layer {
           startX: startX,
           startY: startY,
           tintColor: tintColor,
+          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,

--- a/lib/src/layer.dart
+++ b/lib/src/layer.dart
@@ -75,11 +75,13 @@ abstract class Layer {
 
   /// Hex-formatted tint color (#RRGGBB or #AARRGGBB) that is multiplied with
   /// any graphics drawn by this layer or any child layers (optional).
-  String? tintColor;
+  String? tintColorHex;
 
-  /// Parsed [Color] that is multiplied with
-  /// any graphics drawn by this layer or any child layers (optional).
-  Color? tintColor_;
+  /// [Color] that is multiplied with any graphics drawn by this layer or any
+  /// child layers (optional).
+  ///
+  /// Parsed from [tintColorHex], will be null if parsing fails for any reason.
+  Color? tintColor;
 
   /// The opacity of the layer as a value from 0 to 1. Defaults to 1.
   double opacity;
@@ -103,8 +105,8 @@ abstract class Layer {
     this.parallaxY = 1,
     this.startX,
     this.startY,
+    this.tintColorHex,
     this.tintColor,
-    this.tintColor_,
     this.opacity = 1,
     this.visible = true,
     this.properties = const [],
@@ -127,8 +129,8 @@ abstract class Layer {
     final parallaxY = parser.getDouble('parallaxy', defaults: 1);
     final startX = parser.getIntOrNull('startx');
     final startY = parser.getIntOrNull('starty');
-    final tintColor = parser.getStringOrNull('tintcolor');
-    final tintColor_ = parser.getColorOrNull('tintcolor');
+    final tintColorHex = parser.getStringOrNull('tintcolor');
+    final tintColor = parser.getColorOrNull('tintcolor');
     final opacity = parser.getDouble('opacity', defaults: 1);
     final visible = parser.getBool('visible', defaults: true);
     final properties = parser.getProperties();
@@ -165,8 +167,8 @@ abstract class Layer {
           parallaxY: parallaxY,
           startX: startX,
           startY: startY,
+          tintColorHex: tintColorHex,
           tintColor: tintColor,
-          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
@@ -183,9 +185,9 @@ abstract class Layer {
           'draworder',
           defaults: DrawOrder.topDown,
         );
-        final color =
+        final colorHex =
             parser.getString('color', defaults: ObjectGroup.defaultColorHex);
-        final color_ =
+        final color =
             parser.getColor('color', defaults: ObjectGroup.defaultColor);
         final objects = parser.getChildrenAs('object', TiledObject.parse);
         layer = ObjectGroup(
@@ -200,20 +202,20 @@ abstract class Layer {
           parallaxY: parallaxY,
           startX: startX,
           startY: startY,
+          tintColorHex: tintColorHex,
           tintColor: tintColor,
-          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
           drawOrder: drawOrder,
           objects: objects,
+          colorHex: colorHex,
           color: color,
-          color_: color_,
         );
         break;
       case LayerType.imageLayer:
-        final transparentColor = parser.getStringOrNull('transparentcolor');
-        final transparentColor_ = parser.getColorOrNull('transparentcolor');
+        final transparentColorHex = parser.getStringOrNull('transparentcolor');
+        final transparentColor = parser.getColorOrNull('transparentcolor');
         final image = parser.getSingleChildAs('image', TiledImage.parse);
         final repeatX = parser.getBool('repeatx', defaults: false);
         final repeatY = parser.getBool('repeaty', defaults: false);
@@ -231,14 +233,14 @@ abstract class Layer {
           repeatY: repeatY,
           startX: startX,
           startY: startY,
+          tintColorHex: tintColorHex,
           tintColor: tintColor,
-          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
           image: image,
+          transparentColorHex: transparentColorHex,
           transparentColor: transparentColor,
-          transparentColor_: transparentColor_,
         );
         break;
       case LayerType.group:
@@ -255,8 +257,8 @@ abstract class Layer {
           parallaxY: parallaxY,
           startX: startX,
           startY: startY,
+          tintColorHex: tintColorHex,
           tintColor: tintColor,
-          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
@@ -390,8 +392,8 @@ class TileLayer extends Layer {
     double parallaxY = 1,
     int? startX,
     int? startY,
-    String? tintColor,
-    Color? tintColor_,
+    String? tintColorHex,
+    Color? tintColor,
     double opacity = 1,
     bool visible = true,
     List<Property> properties = const [],
@@ -415,8 +417,8 @@ class TileLayer extends Layer {
           parallaxY: parallaxY,
           startX: startX,
           startY: startY,
+          tintColorHex: tintColorHex,
           tintColor: tintColor,
-          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
@@ -444,13 +446,16 @@ class ObjectGroup extends Layer {
   /// List of [TiledObject].
   List<TiledObject> objects;
 
-  /// The color used to display the objects in this group.
-  /// (defaults to gray (“#a0a0a4”))
-  String color;
+  /// Hex-formatted color (#RRGGBB or #AARRGGBB) used to display the objects in
+  /// this group. (defaults to gray (“#a0a0a4”))
+  String colorHex;
 
-  /// The [Color] used to display the objects in this group.
+  /// [Color] used to display the objects in this group.
   /// (defaults to gray (“#a0a0a4”))
-  Color color_;
+  ///
+  /// Parsed from [colorHex], will be fallback to [defaultColor] if parsing
+  /// fails for any reason.
+  Color color;
 
   ObjectGroup({
     int? id,
@@ -464,15 +469,15 @@ class ObjectGroup extends Layer {
     double parallaxY = 1,
     int? startX,
     int? startY,
-    String? tintColor,
-    Color? tintColor_,
+    String? tintColorHex,
+    Color? tintColor,
     double opacity = 1,
     bool visible = true,
     List<Property> properties = const [],
     this.drawOrder = DrawOrder.topDown,
     required this.objects,
-    this.color = defaultColorHex,
-    this.color_ = defaultColor,
+    this.colorHex = defaultColorHex,
+    this.color = defaultColor,
   }) : super(
           id: id,
           name: name,
@@ -486,8 +491,8 @@ class ObjectGroup extends Layer {
           parallaxY: parallaxY,
           startX: startX,
           startY: startY,
+          tintColorHex: tintColorHex,
           tintColor: tintColor,
-          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
@@ -498,11 +503,15 @@ class ImageLayer extends Layer {
   /// Image used by this layer.
   TiledImage image;
 
-  /// Hex-formatted color (#RRGGBB) to be rendered as transparent (optional).
-  String? transparentColor;
+  /// Hex-formatted color (#RRGGBB or #AARRGGBB) to be rendered as transparent
+  /// (optional).
+  String? transparentColorHex;
 
   /// [Color] to be rendered as transparent (optional).
-  Color? transparentColor_;
+  ///
+  /// Parsed from [transparentColorHex], will be null if parsing fails for any
+  /// reason.
+  Color? transparentColor;
 
   /// Whether or not to repeat the image on the X-axis
   bool repeatX;
@@ -522,16 +531,16 @@ class ImageLayer extends Layer {
     double parallaxY = 1,
     int? startX,
     int? startY,
-    String? tintColor,
-    Color? tintColor_,
+    String? tintColorHex,
+    Color? tintColor,
     double opacity = 1,
     bool visible = true,
     List<Property> properties = const [],
     required this.image,
     required this.repeatX,
     required this.repeatY,
+    this.transparentColorHex,
     this.transparentColor,
-    this.transparentColor_,
   }) : super(
           id: id,
           name: name,
@@ -545,8 +554,8 @@ class ImageLayer extends Layer {
           parallaxY: parallaxY,
           startX: startX,
           startY: startY,
+          tintColorHex: tintColorHex,
           tintColor: tintColor,
-          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,
@@ -569,8 +578,8 @@ class Group extends Layer {
     double parallaxY = 1,
     int? startX,
     int? startY,
-    String? tintColor,
-    Color? tintColor_,
+    String? tintColorHex,
+    Color? tintColor,
     double opacity = 1,
     bool visible = true,
     List<Property> properties = const [],
@@ -588,8 +597,8 @@ class Group extends Layer {
           parallaxY: parallaxY,
           startX: startX,
           startY: startY,
+          tintColorHex: tintColorHex,
           tintColor: tintColor,
-          tintColor_: tintColor_,
           opacity: opacity,
           visible: visible,
           properties: properties,

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -197,6 +197,35 @@ abstract class Parser {
     return result;
   }
 
+  Color? getColorOrNull(String name, {Color? defaults}) {
+    final tiledColor = getStringOrNull(name);
+
+    // Tiled colors are stored as either ARGB or RGB hex values, so we can
+    // parse them as hex numbers with a little coercing.
+    int? colorValue;
+    if (tiledColor?.length == 7) {
+      // parse '#rrbbgg'  as hex '0xaarrggbb' with the alpha channel on full
+      colorValue = int.tryParse(tiledColor!.replaceFirst('#', '0xff'));
+    } else if (tiledColor?.length == 9) {
+      // parse '#aarrbbgg'  as hex '0xaarrggbb'
+      colorValue = int.tryParse(tiledColor!.replaceFirst('#', '0x'));
+    }
+
+    if (colorValue != null) {
+      return Color(colorValue);
+    } else {
+      return defaults;
+    }
+  }
+
+  Color getColor(String name, {Color? defaults}) {
+    final result = getColorOrNull(name, defaults: defaults);
+    if (result == null) {
+      throw ParsingException(name, null, 'Missing required color field');
+    }
+    return result;
+  }
+
   T? getRawEnumOrNull<T>(
     List<T> values,
     String Function(T) namer,

--- a/lib/src/tiled_map.dart
+++ b/lib/src/tiled_map.dart
@@ -70,6 +70,7 @@ class TiledMap {
   List<Layer> layers;
 
   String? backgroundColor;
+  Color? backgroundColor_;
   int compressionLevel;
 
   int? nextLayerId;
@@ -97,6 +98,7 @@ class TiledMap {
     this.tilesets = const [],
     this.layers = const [],
     this.backgroundColor,
+    this.backgroundColor_,
     this.compressionLevel = -1,
     this.hexSideLength,
     this.nextLayerId,
@@ -225,6 +227,7 @@ class TiledMap {
 
   static TiledMap parse(Parser parser, {List<TsxProvider>? tsxList}) {
     final backgroundColor = parser.getStringOrNull('backgroundcolor');
+    final backgroundColor_ = parser.getColorOrNull('backgroundcolor');
     final compressionLevel = parser.getInt('compressionlevel', defaults: -1);
     final height = parser.getInt('height');
     final hexSideLength = parser.getIntOrNull('hexsidelength');
@@ -281,6 +284,7 @@ class TiledMap {
       tilesets: tilesets,
       layers: layers,
       backgroundColor: backgroundColor,
+      backgroundColor_: backgroundColor_,
       compressionLevel: compressionLevel,
       hexSideLength: hexSideLength,
       nextLayerId: nextLayerId,

--- a/lib/src/tiled_map.dart
+++ b/lib/src/tiled_map.dart
@@ -69,8 +69,17 @@ class TiledMap {
   List<Tileset> tilesets;
   List<Layer> layers;
 
-  String? backgroundColor;
-  Color? backgroundColor_;
+  /// Hex-formatted color (#RRGGBB or #AARRGGBB) to be rendered as a solid color
+  /// behind all other layers (optional).
+  String? backgroundColorHex;
+
+  /// [Color] to be rendered as a solid color behind all other layers
+  /// (optional).
+  ///
+  /// Parsed from [backgroundColorHex], will be null if parsing fails for any
+  /// reason.
+  Color? backgroundColor;
+
   int compressionLevel;
 
   int? nextLayerId;
@@ -97,8 +106,8 @@ class TiledMap {
     required this.tileHeight,
     this.tilesets = const [],
     this.layers = const [],
+    this.backgroundColorHex,
     this.backgroundColor,
-    this.backgroundColor_,
     this.compressionLevel = -1,
     this.hexSideLength,
     this.nextLayerId,
@@ -226,8 +235,8 @@ class TiledMap {
   }
 
   static TiledMap parse(Parser parser, {List<TsxProvider>? tsxList}) {
-    final backgroundColor = parser.getStringOrNull('backgroundcolor');
-    final backgroundColor_ = parser.getColorOrNull('backgroundcolor');
+    final backgroundColorHex = parser.getStringOrNull('backgroundcolor');
+    final backgroundColor = parser.getColorOrNull('backgroundcolor');
     final compressionLevel = parser.getInt('compressionlevel', defaults: -1);
     final height = parser.getInt('height');
     final hexSideLength = parser.getIntOrNull('hexsidelength');
@@ -283,8 +292,8 @@ class TiledMap {
       tileHeight: tileHeight,
       tilesets: tilesets,
       layers: layers,
+      backgroundColorHex: backgroundColorHex,
       backgroundColor: backgroundColor,
-      backgroundColor_: backgroundColor_,
       compressionLevel: compressionLevel,
       hexSideLength: hexSideLength,
       nextLayerId: nextLayerId,

--- a/lib/tiled.dart
+++ b/lib/tiled.dart
@@ -3,6 +3,7 @@ library tiled;
 import 'dart:convert';
 import 'dart:math' show Rectangle;
 import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:archive/archive.dart';
 import 'package:meta/meta.dart';

--- a/test/fixtures/test.tmx
+++ b/test/fixtures/test.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.2.1" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1">
+<map version="1.2" tiledversion="1.2.1" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1" backgroundcolor="#ccddaaff">
  <tileset firstgid="1" name="basketball" tilewidth="32" tileheight="32" tilecount="2" columns="1">
   <properties>
    <property name="test_property" value="test_value"/>
@@ -16,7 +16,7 @@
    </properties>
   </tile>
  </tileset>
- <layer id="1" name="Tile Layer 1" width="10" height="10" class="layer1Class">
+ <layer id="1" name="Tile Layer 1" width="10" height="10" class="layer1Class" tintcolor="#ffaabb">
   <data encoding="base64" compression="zlib">
    eJxjZCAeMI6qpblaAAl0AAs=
   </data>

--- a/test/layer_test.dart
+++ b/test/layer_test.dart
@@ -73,9 +73,11 @@ void main() {
     });
 
     test('parsed colors', () {
-      expect(layer.tintColor, equals('#ffaabb'));
+      expect(layer.tintColorHex, equals('#ffaabb'));
       expect(
-          layer.tintColor_, equals(const Color.fromARGB(255, 255, 170, 187)));
+        layer.tintColor,
+        equals(Color(int.parse('0xffffaabb'))),
+      );
     });
   });
 }

--- a/test/layer_test.dart
+++ b/test/layer_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:test/test.dart';
 import 'package:tiled/tiled.dart';
@@ -69,6 +70,12 @@ void main() {
       layer.tileData!.forEach((row) {
         expect(row.length, equals(10));
       });
+    });
+
+    test('parsed colors', () {
+      expect(layer.tintColor, equals('#ffaabb'));
+      expect(
+          layer.tintColor_, equals(const Color.fromARGB(255, 255, 170, 187)));
     });
   });
 }

--- a/test/object_group_test.dart
+++ b/test/object_group_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:test/test.dart';
 import 'package:tiled/tiled.dart';
@@ -28,6 +29,10 @@ void main() {
 
     test('sets color', () {
       expect(objectGroup.color, equals('#555500'));
+      expect(
+        objectGroup.color_,
+        equals(const Color.fromARGB(255, 85, 85, 0)),
+      );
     });
 
     test('sets opacity', () {

--- a/test/object_group_test.dart
+++ b/test/object_group_test.dart
@@ -28,10 +28,10 @@ void main() {
     });
 
     test('sets color', () {
-      expect(objectGroup.color, equals('#555500'));
+      expect(objectGroup.colorHex, equals('#555500'));
       expect(
-        objectGroup.color_,
-        equals(const Color.fromARGB(255, 85, 85, 0)),
+        objectGroup.color,
+        equals(Color(int.parse('0xff555500'))),
       );
     });
 

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:math' show Rectangle;
+import 'dart:ui';
 
 import 'package:test/test.dart';
 import 'package:tiled/tiled.dart';
@@ -37,6 +38,12 @@ void main() {
   group('Parser.parse populates Map with tilesets', () {
     test('and Map.tilesets is the correct size', () {
       expect(map.tilesets.length, equals(1));
+    });
+
+    test('and Map.backgroundColor is the correct', () {
+      expect(map.backgroundColor, equals('#ccddaaff'));
+      expect(map.backgroundColor_,
+          equals(const Color.fromARGB(204, 221, 170, 255)));
     });
 
     group('and the first tileset', () {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -41,9 +41,11 @@ void main() {
     });
 
     test('and Map.backgroundColor is the correct', () {
-      expect(map.backgroundColor, equals('#ccddaaff'));
-      expect(map.backgroundColor_,
-          equals(const Color.fromARGB(204, 221, 170, 255)));
+      expect(map.backgroundColorHex, equals('#ccddaaff'));
+      expect(
+        map.backgroundColor,
+        equals(Color(int.parse('0xccddaaff'))),
+      );
     });
 
     group('and the first tileset', () {


### PR DESCRIPTION
Adding direct support for parsing color hex strings as `dart.ui.Color` objects, which is the primary type the interoperates with Dart rendering libraries and most `Canvas` methods use.

Also, should eventually replace [`_parseTiledColor` in `flame_tiled` `RenderableTileMap`](https://github.com/flame-engine/flame/blob/flame_tiled-v1.7.2/packages/flame_tiled/lib/src/renderable_tile_map.dart#L416-L430). 