### PR TITLE
feat!: turning List<Property> into CustomProperties

### DIFF
--- a/packages/tiled/lib/src/common/property.dart
+++ b/packages/tiled/lib/src/common/property.dart
@@ -119,13 +119,18 @@ class CustomProperties extends Iterable<Property> {
   ///  - color property -> ui.Color
   ///  - file property -> string (path)
   ///  - object property -> int (ID)
-  T get<T>(String name) {
-    return getProp(name).value as T;
+  T getValue<T>(String name) {
+    return getProperty(name).value as T;
   }
 
   /// Get a typed property by its name
-  T getProp<T extends Property<dynamic>>(String name) {
+  T getProperty<T extends Property<dynamic>>(String name) {
     return byName[name]! as T;
+  }
+
+  /// Get a property by its name
+  Property<dynamic> operator [](String name) {
+    return getProperty(name);
   }
 
   @override

--- a/packages/tiled/lib/src/common/property.dart
+++ b/packages/tiled/lib/src/common/property.dart
@@ -23,7 +23,7 @@ class Property<T> {
     required this.value,
   });
 
-  static Property parse(Parser parser) {
+  static Property<Object> parse(Parser parser) {
     final name = parser.getString('name');
     final type = parser.getPropertyType('type', defaults: PropertyType.string);
 
@@ -100,11 +100,11 @@ class Property<T> {
 /// properties.getProp<IntProperty>('foo') ==
 ///     IntProperty(name: 'foo', value: 3);
 /// ```
-class CustomProperties extends Iterable<Property> {
+class CustomProperties extends Iterable<Property<Object>> {
   static const empty = CustomProperties({});
 
   /// The properties, indexed by name
-  final Map<String, Property> byName;
+  final Map<String, Property<Object>> byName;
 
   const CustomProperties(this.byName);
 
@@ -120,16 +120,16 @@ class CustomProperties extends Iterable<Property> {
   ///  - file property -> string (path)
   ///  - object property -> int (ID)
   T? getValue<T>(String name) {
-    return getProperty(name)?.value as T;
+    return getProperty(name)?.value as T?;
   }
 
   /// Get a typed property by its name
-  T? getProperty<T extends Property<dynamic>>(String name) {
-    return byName[name]! as T;
+  T? getProperty<T extends Property<Object>>(String name) {
+    return byName[name] as T?;
   }
 
   /// Get a property by its name
-  Property? operator [](String name) {
+  Property<Object>? operator [](String name) {
     return byName[name];
   }
 
@@ -139,7 +139,7 @@ class CustomProperties extends Iterable<Property> {
   }
 
   @override
-  Iterator<Property> get iterator => byName.values.iterator;
+  Iterator<Property<Object>> get iterator => byName.values.iterator;
 }
 
 /// [value] is the ID of the object

--- a/packages/tiled/lib/src/common/property.dart
+++ b/packages/tiled/lib/src/common/property.dart
@@ -88,15 +88,43 @@ class Property<T> {
   }
 }
 
+/// A wrapper for a Tiled property set
+///
+/// Accessing an int value
+/// ```dart
+/// properties.get<int>('foo') == 3
+/// ```
+///
+/// Accessing an int property:
+/// ```dart
+/// properties.getProp<IntProperty>('foo') ==
+///     IntProperty(name: 'foo', value: 3);
+/// ```
 class CustomProperties extends Iterable<Property> {
   static const empty = CustomProperties({});
 
+  /// The properties, indexed by name
   final Map<String, Property> byName;
 
   const CustomProperties(this.byName);
 
+  /// Get a property value by its name.
+  ///
+  /// [T] must be the type of the value, which depends on the property type.
+  /// The following Tiled properties map to the follow Dart types:
+  ///  - int property -> int
+  ///  - float property -> double
+  ///  - boolean property -> bool
+  ///  - string property -> string
+  ///  - color property -> ui.Color
+  ///  - file property -> string (path)
+  ///  - object property -> int (ID)
+  T get<T>(String name) {
+    return getProp(name).value as T;
+  }
+
   /// Get a typed property by its name
-  T named<T extends Property<dynamic>>(String name) {
+  T getProp<T extends Property<dynamic>>(String name) {
     return byName[name]! as T;
   }
 

--- a/packages/tiled/lib/src/common/property.dart
+++ b/packages/tiled/lib/src/common/property.dart
@@ -33,8 +33,8 @@ class Property {
 }
 
 extension PropertiesParser on Parser {
-  List<Property> getProperties() {
-    return formatSpecificParsing(
+  Map<String, Property> getProperties() {
+    final properties = formatSpecificParsing(
       (json) => json.getChildrenAs('properties', Property.parse),
       (xml) =>
           xml
@@ -42,5 +42,12 @@ extension PropertiesParser on Parser {
               ?.getChildrenAs('property', Property.parse) ??
           [],
     );
+
+    return properties.groupFoldBy((prop) => prop.name, (previous, element) {
+      if (previous != null) {
+        throw ArgumentError("Can't have two properties with the same name.");
+      }
+      return element;
+    });
   }
 }

--- a/packages/tiled/lib/src/common/property.dart
+++ b/packages/tiled/lib/src/common/property.dart
@@ -97,8 +97,13 @@ class Property<T> {
 ///
 /// Accessing an int property:
 /// ```dart
-/// properties.getProp<IntProperty>('foo') ==
+/// properties.getProperty<IntProperty>('foo') ==
 ///     IntProperty(name: 'foo', value: 3);
+/// ```
+///
+/// You can also use an accessor:
+/// ```dart
+/// properties['foo'] == IntProperty(name: 'foo', value: 3);
 /// ```
 class CustomProperties extends Iterable<Property<Object>> {
   static const empty = CustomProperties({});

--- a/packages/tiled/lib/src/common/property.dart
+++ b/packages/tiled/lib/src/common/property.dart
@@ -119,18 +119,23 @@ class CustomProperties extends Iterable<Property> {
   ///  - color property -> ui.Color
   ///  - file property -> string (path)
   ///  - object property -> int (ID)
-  T getValue<T>(String name) {
-    return getProperty(name).value as T;
+  T? getValue<T>(String name) {
+    return getProperty(name)?.value as T;
   }
 
   /// Get a typed property by its name
-  T getProperty<T extends Property<dynamic>>(String name) {
+  T? getProperty<T extends Property<dynamic>>(String name) {
     return byName[name]! as T;
   }
 
   /// Get a property by its name
-  Property<dynamic> operator [](String name) {
-    return getProperty(name);
+  Property? operator [](String name) {
+    return byName[name];
+  }
+
+  /// Returns whether or not a property with [name] exists.
+  bool has(String name) {
+    return byName.containsKey(name);
   }
 
   @override

--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -90,7 +90,7 @@ abstract class Layer {
   bool visible;
 
   /// List of [Property].
-  Map<String, Property> properties;
+  CustomProperties properties;
 
   Layer({
     this.id,
@@ -109,7 +109,7 @@ abstract class Layer {
     this.tintColor,
     this.opacity = 1,
     this.visible = true,
-    this.properties = const {},
+    this.properties = CustomProperties.empty,
   });
 
   static Layer parse(Parser parser) {

--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -90,7 +90,7 @@ abstract class Layer {
   bool visible;
 
   /// List of [Property].
-  List<Property> properties;
+  Map<String, Property> properties;
 
   Layer({
     this.id,
@@ -109,7 +109,7 @@ abstract class Layer {
     this.tintColor,
     this.opacity = 1,
     this.visible = true,
-    this.properties = const [],
+    this.properties = const {},
   });
 
   static Layer parse(Parser parser) {

--- a/packages/tiled/lib/src/objects/tiled_object.dart
+++ b/packages/tiled/lib/src/objects/tiled_object.dart
@@ -65,7 +65,7 @@ class TiledObject {
 
   List<Point> polygon;
   List<Point> polyline;
-  Map<String, Property> properties;
+  CustomProperties properties;
 
   /// The "Class" property, a.k.a "Type" prior to Tiled 1.9.
   /// Will be same as [type].
@@ -89,7 +89,7 @@ class TiledObject {
     this.visible = true,
     this.polygon = const [],
     this.polyline = const [],
-    this.properties = const {},
+    this.properties = CustomProperties.empty,
   });
 
   bool get isPolyline => polyline.isNotEmpty;

--- a/packages/tiled/lib/src/objects/tiled_object.dart
+++ b/packages/tiled/lib/src/objects/tiled_object.dart
@@ -65,7 +65,7 @@ class TiledObject {
 
   List<Point> polygon;
   List<Point> polyline;
-  List<Property> properties;
+  Map<String, Property> properties;
 
   /// The "Class" property, a.k.a "Type" prior to Tiled 1.9.
   /// Will be same as [type].
@@ -89,7 +89,7 @@ class TiledObject {
     this.visible = true,
     this.polygon = const [],
     this.polyline = const [],
-    this.properties = const [],
+    this.properties = const {},
   });
 
   bool get isPolyline => polyline.isNotEmpty;

--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -89,7 +89,7 @@ class TiledMap {
   RenderOrder renderOrder;
 
   List<EditorSetting> editorSettings;
-  Map<String, Property> properties;
+  CustomProperties properties;
 
   // only for hexagonal maps:
   int? hexSideLength;
@@ -118,7 +118,7 @@ class TiledMap {
     this.staggerAxis,
     this.staggerIndex,
     this.editorSettings = const [],
-    this.properties = const {},
+    this.properties = CustomProperties.empty,
   });
 
   /// Takes a string [contents] and converts it to a [TiledMap] with the help of

--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -89,7 +89,7 @@ class TiledMap {
   RenderOrder renderOrder;
 
   List<EditorSetting> editorSettings;
-  List<Property> properties;
+  Map<String, Property> properties;
 
   // only for hexagonal maps:
   int? hexSideLength;
@@ -118,7 +118,7 @@ class TiledMap {
     this.staggerAxis,
     this.staggerIndex,
     this.editorSettings = const [],
-    this.properties = const [],
+    this.properties = const {},
   });
 
   /// Takes a string [contents] and converts it to a [TiledMap] with the help of

--- a/packages/tiled/lib/src/tileset/terrain.dart
+++ b/packages/tiled/lib/src/tileset/terrain.dart
@@ -12,12 +12,12 @@ part of tiled;
 class Terrain {
   String name;
   int tile;
-  Map<String, Property> properties;
+  CustomProperties properties;
 
   Terrain({
     required this.name,
     required this.tile,
-    this.properties = const {},
+    this.properties = CustomProperties.empty,
   });
 
   Terrain.parse(Parser parser)

--- a/packages/tiled/lib/src/tileset/terrain.dart
+++ b/packages/tiled/lib/src/tileset/terrain.dart
@@ -12,12 +12,12 @@ part of tiled;
 class Terrain {
   String name;
   int tile;
-  List<Property> properties;
+  Map<String, Property> properties;
 
   Terrain({
     required this.name,
     required this.tile,
-    this.properties = const [],
+    this.properties = const {},
   });
 
   Terrain.parse(Parser parser)

--- a/packages/tiled/lib/src/tileset/tile.dart
+++ b/packages/tiled/lib/src/tileset/tile.dart
@@ -29,7 +29,7 @@ class Tile {
   TiledImage? image;
   Layer? objectGroup;
   List<Frame> animation;
-  List<Property> properties;
+  Map<String, Property> properties;
 
   Tile({
     required this.localId,
@@ -39,7 +39,7 @@ class Tile {
     this.image,
     this.objectGroup,
     this.animation = const [],
-    this.properties = const [],
+    this.properties = const {},
   });
 
   bool get isEmpty => localId == -1;

--- a/packages/tiled/lib/src/tileset/tile.dart
+++ b/packages/tiled/lib/src/tileset/tile.dart
@@ -29,7 +29,7 @@ class Tile {
   TiledImage? image;
   Layer? objectGroup;
   List<Frame> animation;
-  Map<String, Property> properties;
+  CustomProperties properties;
 
   Tile({
     required this.localId,
@@ -39,7 +39,7 @@ class Tile {
     this.image,
     this.objectGroup,
     this.animation = const [],
-    this.properties = const {},
+    this.properties = CustomProperties.empty,
   });
 
   bool get isEmpty => localId == -1;

--- a/packages/tiled/lib/src/tileset/tileset.dart
+++ b/packages/tiled/lib/src/tileset/tileset.dart
@@ -60,7 +60,7 @@ class Tileset {
   TiledImage? image;
   TileOffset? tileOffset;
   Grid? grid;
-  List<Property> properties = [];
+  Map<String, Property> properties = {};
   List<Terrain> terrains = [];
   List<WangSet> wangSets = [];
 
@@ -85,7 +85,7 @@ class Tileset {
     this.image,
     this.tileOffset,
     this.grid,
-    this.properties = const [],
+    this.properties = const {},
     this.terrains = const [],
     this.wangSets = const [],
     this.version = '1.0',

--- a/packages/tiled/lib/src/tileset/tileset.dart
+++ b/packages/tiled/lib/src/tileset/tileset.dart
@@ -60,7 +60,7 @@ class Tileset {
   TiledImage? image;
   TileOffset? tileOffset;
   Grid? grid;
-  Map<String, Property> properties = {};
+  CustomProperties properties;
   List<Terrain> terrains = [];
   List<WangSet> wangSets = [];
 
@@ -85,7 +85,7 @@ class Tileset {
     this.image,
     this.tileOffset,
     this.grid,
-    this.properties = const {},
+    this.properties = CustomProperties.empty,
     this.terrains = const [],
     this.wangSets = const [],
     this.version = '1.0',
@@ -185,7 +185,7 @@ class Tileset {
       tileWidth = tileset.tileWidth ?? tileWidth;
       transparentColor = tileset.transparentColor ?? transparentColor;
       // Add List-Attributes
-      properties.addAll(tileset.properties);
+      properties.byName.addAll(tileset.properties.byName);
       terrains.addAll(tileset.terrains);
       tiles.addAll(tileset.tiles);
       wangSets.addAll(tileset.wangSets);

--- a/packages/tiled/lib/src/tileset/wang/wang_color.dart
+++ b/packages/tiled/lib/src/tileset/wang/wang_color.dart
@@ -19,14 +19,14 @@ class WangColor {
   int tile;
   double probability;
 
-  List<Property> properties;
+  Map<String, Property> properties;
 
   WangColor({
     required this.name,
     required this.color,
     required this.tile,
     this.probability = 0,
-    this.properties = const [],
+    this.properties = const {},
   });
 
   WangColor.parse(Parser parser)

--- a/packages/tiled/lib/src/tileset/wang/wang_color.dart
+++ b/packages/tiled/lib/src/tileset/wang/wang_color.dart
@@ -19,14 +19,14 @@ class WangColor {
   int tile;
   double probability;
 
-  Map<String, Property> properties;
+  CustomProperties properties;
 
   WangColor({
     required this.name,
     required this.color,
     required this.tile,
     this.probability = 0,
-    this.properties = const {},
+    this.properties = CustomProperties.empty,
   });
 
   WangColor.parse(Parser parser)

--- a/packages/tiled/lib/src/tileset/wang/wang_set.dart
+++ b/packages/tiled/lib/src/tileset/wang/wang_set.dart
@@ -21,7 +21,7 @@ class WangSet {
   List<WangColor> cornerColors;
   List<WangColor> edgeColors;
   List<WangTile> wangTiles;
-  List<Property> properties;
+  Map<String, Property> properties;
 
   WangSet({
     required this.name,
@@ -29,7 +29,7 @@ class WangSet {
     this.cornerColors = const [],
     this.edgeColors = const [],
     this.wangTiles = const [],
-    this.properties = const [],
+    this.properties = const {},
   });
 
   factory WangSet.parse(Parser parser) {

--- a/packages/tiled/lib/src/tileset/wang/wang_set.dart
+++ b/packages/tiled/lib/src/tileset/wang/wang_set.dart
@@ -21,7 +21,7 @@ class WangSet {
   List<WangColor> cornerColors;
   List<WangColor> edgeColors;
   List<WangTile> wangTiles;
-  Map<String, Property> properties;
+  CustomProperties properties;
 
   WangSet({
     required this.name,
@@ -29,7 +29,7 @@ class WangSet {
     this.cornerColors = const [],
     this.edgeColors = const [],
     this.wangTiles = const [],
-    this.properties = const {},
+    this.properties = CustomProperties.empty,
   });
 
   factory WangSet.parse(Parser parser) {

--- a/packages/tiled/test/fixtures/test.tmx
+++ b/packages/tiled/test/fixtures/test.tmx
@@ -2,7 +2,15 @@
 <map version="1.2" tiledversion="1.2.1" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1" backgroundcolor="#ccddaaff">
  <tileset firstgid="1" name="basketball" tilewidth="32" tileheight="32" tilecount="2" columns="1">
   <properties>
-   <property name="test_property" value="test_value"/>
+   <property name="string property" value="test_value"/>
+   <property name="multiline string">Hello,
+World</property>
+   <property name="integer property" type="int" value="42"/>
+   <property name="bool property" type="bool" value="true"/>
+   <property name="color property" type="color" value="#00112233"/>
+   <property name="float property" type="float" value="1.56"/>
+   <property name="file property" type="file" value="./icons.png"/>
+   <property name="object property" type="object" value="32"/>
   </properties>
   <image source="icons.png" width="32" height="32"/>
   <tile id="0" class="tile0Class">

--- a/packages/tiled/test/map_test.dart
+++ b/packages/tiled/test/map_test.dart
@@ -41,13 +41,13 @@ void main() {
               Tile(localId: 0),
               Tile(
                 localId: 2,
-                properties: [
-                  Property(
+                properties: {
+                  'name': Property(
                     name: 'name',
                     type: PropertyType.string,
-                    value: 'value',
+                    value: 'tile2-prop-value',
                   ),
-                ],
+                },
               ),
             ],
           ),
@@ -66,7 +66,7 @@ void main() {
       final tile = map.tileByGid(7);
 
       expect(tile?.localId, equals(2));
-      expect(tile?.properties.first.name, equals('name'));
+      expect(tile?.properties['name']!.value, equals('tile2-prop-value'));
     });
   });
 

--- a/packages/tiled/test/map_test.dart
+++ b/packages/tiled/test/map_test.dart
@@ -65,8 +65,9 @@ void main() {
       final tile = map.tileByGid(7);
 
       expect(tile?.localId, equals(2));
+      expect(tile?.properties['name'], isA<StringProperty>());
       expect(
-        tile?.properties.get<String>('name'),
+        tile?.properties.getValue<String>('name'),
         equals('tile2-prop-value'),
       );
     });

--- a/packages/tiled/test/map_test.dart
+++ b/packages/tiled/test/map_test.dart
@@ -41,13 +41,12 @@ void main() {
               Tile(localId: 0),
               Tile(
                 localId: 2,
-                properties: {
-                  'name': Property(
+                properties: CustomProperties({
+                  'name': StringProperty(
                     name: 'name',
-                    type: PropertyType.string,
                     value: 'tile2-prop-value',
                   ),
-                },
+                }),
               ),
             ],
           ),
@@ -66,7 +65,10 @@ void main() {
       final tile = map.tileByGid(7);
 
       expect(tile?.localId, equals(2));
-      expect(tile?.properties['name']!.value, equals('tile2-prop-value'));
+      expect(
+        tile?.properties.named<StringProperty>('name').value,
+        equals('tile2-prop-value'),
+      );
     });
   });
 

--- a/packages/tiled/test/map_test.dart
+++ b/packages/tiled/test/map_test.dart
@@ -66,7 +66,7 @@ void main() {
 
       expect(tile?.localId, equals(2));
       expect(
-        tile?.properties.named<StringProperty>('name').value,
+        tile?.properties.get<String>('name'),
         equals('tile2-prop-value'),
       );
     });

--- a/packages/tiled/test/parser_test.dart
+++ b/packages/tiled/test/parser_test.dart
@@ -96,7 +96,7 @@ void main() {
             equals(42),
           );
           expect(
-            properties.getProperty<ColorProperty>('color property').hexValue,
+            properties.getProperty<ColorProperty>('color property')!.hexValue,
             equals('#00112233'),
           );
           expect(
@@ -144,6 +144,10 @@ void main() {
         });
 
         test('inserting properties into tileProperties based on Tile GID', () {
+          expect(
+            tile1Properties.has('tile_0_property_name'),
+            isTrue,
+          );
           expect(
             tile1Properties.getValue<String>('tile_0_property_name'),
             equals('tile_0_property_value'),

--- a/packages/tiled/test/parser_test.dart
+++ b/packages/tiled/test/parser_test.dart
@@ -84,35 +84,35 @@ void main() {
         test('has a key of "test_property" = "test_value"', () {
           expect(properties.first.name, equals('string property'));
           expect(
-            properties.named<StringProperty>('string property').value,
+            properties.get<String>('string property'),
             equals('test_value'),
           );
           expect(
-            properties.named<StringProperty>('multiline string').value,
+            properties.get<String>('multiline string'),
             equals('Hello,\nWorld'),
           );
           expect(
-            properties.named<IntProperty>('integer property').value,
+            properties.get<int>('integer property'),
             equals(42),
           );
           expect(
-            properties.named<ColorProperty>('color property').hexValue,
+            properties.getProp<ColorProperty>('color property').hexValue,
             equals('#00112233'),
           );
           expect(
-            properties.named<ColorProperty>('color property').value,
+            properties.get<Color>('color property'),
             equals(const Color(0x00112233)),
           );
           expect(
-            properties.named<FloatProperty>('float property').value,
+            properties.get<double>('float property'),
             equals(1.56),
           );
           expect(
-            properties.named<FileProperty>('file property').value,
+            properties.get<String>('file property'),
             equals('./icons.png'),
           );
           expect(
-            properties.named<ObjectProperty>('object property').value,
+            properties.get<int>('object property'),
             equals(32),
           );
         });
@@ -145,15 +145,11 @@ void main() {
 
         test('inserting properties into tileProperties based on Tile GID', () {
           expect(
-            tile1Properties.named<StringProperty>('tile_0_property_name'),
-            isNotNull,
-          );
-          expect(
-            tile1Properties.named<StringProperty>('tile_0_property_name').value,
+            tile1Properties.get<String>('tile_0_property_name'),
             equals('tile_0_property_value'),
           );
           expect(
-            tile2Properties.named<StringProperty>('tile_1_property_name').value,
+            tile2Properties.get<String>('tile_1_property_name'),
             equals('tile_1_property_value'),
           );
         });

--- a/packages/tiled/test/parser_test.dart
+++ b/packages/tiled/test/parser_test.dart
@@ -79,11 +79,42 @@ void main() {
       });
 
       group('populates its properties correctly and', () {
-        late Map<String, Property> properties;
+        late CustomProperties properties;
         setUp(() => properties = tileset.properties);
         test('has a key of "test_property" = "test_value"', () {
-          expect(properties.values.first.name, equals('test_property'));
-          expect(properties['test_property']!.value, equals('test_value'));
+          expect(properties.first.name, equals('string property'));
+          expect(
+            properties.named<StringProperty>('string property').value,
+            equals('test_value'),
+          );
+          expect(
+            properties.named<StringProperty>('multiline string').value,
+            equals('Hello,\nWorld'),
+          );
+          expect(
+            properties.named<IntProperty>('integer property').value,
+            equals(42),
+          );
+          expect(
+            properties.named<ColorProperty>('color property').hexValue,
+            equals('#00112233'),
+          );
+          expect(
+            properties.named<ColorProperty>('color property').value,
+            equals(const Color(0x00112233)),
+          );
+          expect(
+            properties.named<FloatProperty>('float property').value,
+            equals(1.56),
+          );
+          expect(
+            properties.named<FileProperty>('file property').value,
+            equals('./icons.png'),
+          );
+          expect(
+            properties.named<ObjectProperty>('object property').value,
+            equals(32),
+          );
         });
       });
 
@@ -105,8 +136,8 @@ void main() {
       });
 
       group('populates its child tile properties correctly by', () {
-        late Map<String, Property> tile1Properties;
-        late Map<String, Property> tile2Properties;
+        late CustomProperties tile1Properties;
+        late CustomProperties tile2Properties;
         setUp(() {
           tile1Properties = tileset.tiles[0].properties;
           tile2Properties = tileset.tiles[1].properties;
@@ -114,19 +145,15 @@ void main() {
 
         test('inserting properties into tileProperties based on Tile GID', () {
           expect(
-            tile1Properties['tile_0_property_name']!.name,
-            equals('tile_0_property_name'),
+            tile1Properties.named<StringProperty>('tile_0_property_name'),
+            isNotNull,
           );
           expect(
-            tile1Properties['tile_0_property_name']!.value,
+            tile1Properties.named<StringProperty>('tile_0_property_name').value,
             equals('tile_0_property_value'),
           );
           expect(
-            tile2Properties['tile_1_property_name']!.name,
-            equals('tile_1_property_name'),
-          );
-          expect(
-            tile2Properties['tile_1_property_name']!.value,
+            tile2Properties.named<StringProperty>('tile_1_property_name').value,
             equals('tile_1_property_value'),
           );
         });

--- a/packages/tiled/test/parser_test.dart
+++ b/packages/tiled/test/parser_test.dart
@@ -84,35 +84,35 @@ void main() {
         test('has a key of "test_property" = "test_value"', () {
           expect(properties.first.name, equals('string property'));
           expect(
-            properties.get<String>('string property'),
+            properties.getValue<String>('string property'),
             equals('test_value'),
           );
           expect(
-            properties.get<String>('multiline string'),
+            properties.getValue<String>('multiline string'),
             equals('Hello,\nWorld'),
           );
           expect(
-            properties.get<int>('integer property'),
+            properties.getValue<int>('integer property'),
             equals(42),
           );
           expect(
-            properties.getProp<ColorProperty>('color property').hexValue,
+            properties.getProperty<ColorProperty>('color property').hexValue,
             equals('#00112233'),
           );
           expect(
-            properties.get<Color>('color property'),
+            properties.getValue<Color>('color property'),
             equals(const Color(0x00112233)),
           );
           expect(
-            properties.get<double>('float property'),
+            properties.getValue<double>('float property'),
             equals(1.56),
           );
           expect(
-            properties.get<String>('file property'),
+            properties.getValue<String>('file property'),
             equals('./icons.png'),
           );
           expect(
-            properties.get<int>('object property'),
+            properties.getValue<int>('object property'),
             equals(32),
           );
         });
@@ -145,11 +145,11 @@ void main() {
 
         test('inserting properties into tileProperties based on Tile GID', () {
           expect(
-            tile1Properties.get<String>('tile_0_property_name'),
+            tile1Properties.getValue<String>('tile_0_property_name'),
             equals('tile_0_property_value'),
           );
           expect(
-            tile2Properties.get<String>('tile_1_property_name'),
+            tile2Properties.getValue<String>('tile_1_property_name'),
             equals('tile_1_property_value'),
           );
         });

--- a/packages/tiled/test/parser_test.dart
+++ b/packages/tiled/test/parser_test.dart
@@ -79,11 +79,11 @@ void main() {
       });
 
       group('populates its properties correctly and', () {
-        late List<Property> properties;
+        late Map<String, Property> properties;
         setUp(() => properties = tileset.properties);
         test('has a key of "test_property" = "test_value"', () {
-          expect(properties[0].name, equals('test_property'));
-          expect(properties[0].value, equals('test_value'));
+          expect(properties.values.first.name, equals('test_property'));
+          expect(properties['test_property']!.value, equals('test_value'));
         });
       });
 
@@ -105,18 +105,30 @@ void main() {
       });
 
       group('populates its child tile properties correctly by', () {
-        late List<Property> tile1Properties;
-        late List<Property> tile2Properties;
+        late Map<String, Property> tile1Properties;
+        late Map<String, Property> tile2Properties;
         setUp(() {
           tile1Properties = tileset.tiles[0].properties;
           tile2Properties = tileset.tiles[1].properties;
         });
 
         test('inserting properties into tileProperties based on Tile GID', () {
-          expect(tile1Properties[0].name, equals('tile_0_property_name'));
-          expect(tile1Properties[0].value, equals('tile_0_property_value'));
-          expect(tile2Properties[0].name, equals('tile_1_property_name'));
-          expect(tile2Properties[0].value, equals('tile_1_property_value'));
+          expect(
+            tile1Properties['tile_0_property_name']!.name,
+            equals('tile_0_property_name'),
+          );
+          expect(
+            tile1Properties['tile_0_property_name']!.value,
+            equals('tile_0_property_value'),
+          );
+          expect(
+            tile2Properties['tile_1_property_name']!.name,
+            equals('tile_1_property_name'),
+          );
+          expect(
+            tile2Properties['tile_1_property_name']!.value,
+            equals('tile_1_property_value'),
+          );
         });
       });
     });

--- a/packages/tiled/test/tile_test.dart
+++ b/packages/tiled/test/tile_test.dart
@@ -23,6 +23,6 @@ void main() {
 
   test('Tile.properties is present', () {
     final tile = Tile(localId: -1);
-    expect(tile.properties, isA<Map<String, Property>>());
+    expect(tile.properties, isA<CustomProperties>());
   });
 }

--- a/packages/tiled/test/tile_test.dart
+++ b/packages/tiled/test/tile_test.dart
@@ -23,6 +23,6 @@ void main() {
 
   test('Tile.properties is present', () {
     final tile = Tile(localId: -1);
-    expect(tile.properties, isA<List>());
+    expect(tile.properties, isA<Map<String, Property>>());
   });
 }

--- a/packages/tiled/test/tileset_test.dart
+++ b/packages/tiled/test/tileset_test.dart
@@ -17,7 +17,7 @@ void main() {
     test('spacing == 0', () => expect(tileset.spacing, equals(0)));
     test('margin == 0', () => expect(tileset.margin, equals(0)));
     test('tileProperties == {}', () {
-      expect(tileset.properties, equals(<String, Property>{}));
+      expect(tileset.properties.byName, equals(<String, Property>{}));
     });
   });
 

--- a/packages/tiled/test/tileset_test.dart
+++ b/packages/tiled/test/tileset_test.dart
@@ -17,7 +17,7 @@ void main() {
     test('spacing == 0', () => expect(tileset.spacing, equals(0)));
     test('margin == 0', () => expect(tileset.margin, equals(0)));
     test('tileProperties == {}', () {
-      expect(tileset.properties, equals(<Property>[]));
+      expect(tileset.properties, equals(<String, Property>{}));
     });
   });
 

--- a/packages/tiled/test/tmx_object_test.dart
+++ b/packages/tiled/test/tmx_object_test.dart
@@ -50,7 +50,7 @@ void main() {
         final props = tiledObject.properties;
         expect(props.first.name, equals('property_name'));
         expect(
-          props.get<String>('property_name'),
+          props.getValue<String>('property_name'),
           equals('property_value'),
         );
       });

--- a/packages/tiled/test/tmx_object_test.dart
+++ b/packages/tiled/test/tmx_object_test.dart
@@ -48,8 +48,11 @@ void main() {
 
       test('sets properties', () {
         final props = tiledObject.properties;
-        expect(props['property_name']!.name, equals('property_name'));
-        expect(props['property_name']!.value, equals('property_value'));
+        expect(props.first.name, equals('property_name'));
+        expect(
+          props.named<StringProperty>('property_name').value,
+          equals('property_value'),
+        );
       });
 
       test('sets isEllipse to true', () => expect(tiledObject.ellipse, isTrue));

--- a/packages/tiled/test/tmx_object_test.dart
+++ b/packages/tiled/test/tmx_object_test.dart
@@ -50,7 +50,7 @@ void main() {
         final props = tiledObject.properties;
         expect(props.first.name, equals('property_name'));
         expect(
-          props.named<StringProperty>('property_name').value,
+          props.get<String>('property_name'),
           equals('property_value'),
         );
       });

--- a/packages/tiled/test/tmx_object_test.dart
+++ b/packages/tiled/test/tmx_object_test.dart
@@ -48,8 +48,8 @@ void main() {
 
       test('sets properties', () {
         final props = tiledObject.properties;
-        expect(props[0].name, equals('property_name'));
-        expect(props[0].value, equals('property_value'));
+        expect(props['property_name']!.name, equals('property_name'));
+        expect(props['property_name']!.value, equals('property_value'));
       });
 
       test('sets isEllipse to true', () => expect(tiledObject.ellipse, isTrue));


### PR DESCRIPTION
# Description

See #54 

## Checklist


- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

This is a breaking change, but I'm intentionally not using `feat!` because we don't want to bump the major version.

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

### Migration instructions

Use `properties.named<TypeProperty>('prop_name').value` where applicable. Also, `CustomProperties` implements `Iterable<Property>`.

## Related Issues

Fixes #54 