### PR TITLE
fix: template not parsed

### DIFF
--- a/packages/tiled/lib/src/objects/tiled_object.dart
+++ b/packages/tiled/lib/src/objects/tiled_object.dart
@@ -44,7 +44,7 @@ part of tiled;
 /// Can contain at most one: <properties>, <ellipse> (since 0.9),
 /// <point> (since 1.1), <polygon>, <polyline>, <text> (since 1.0)
 class TiledObject {
-  int id;
+  int? id;
   String name;
   String type;
   int? gid;
@@ -59,7 +59,7 @@ class TiledObject {
   bool point;
   bool rectangle;
 
-  Template? template;
+  Future<Template?>? template;
   Text? text;
   bool visible;
 
@@ -72,7 +72,7 @@ class TiledObject {
   String get class_ => type;
 
   TiledObject({
-    required this.id,
+    this.id,
     this.name = '',
     this.type = '',
     this.gid,
@@ -105,7 +105,7 @@ class TiledObject {
     final width = parser.getDouble('width', defaults: 0);
     final rotation = parser.getDouble('rotation', defaults: 0);
     final visible = parser.getBool('visible', defaults: true);
-    final id = parser.getInt('id');
+    final id = parser.getIntOrNull('id');
     final gid = parser.getIntOrNull('gid');
     final name = parser.getString('name', defaults: '');
 
@@ -126,7 +126,8 @@ class TiledObject {
       (xml) => xml.getChildren('point').isNotEmpty,
     );
     final text = parser.getSingleChildOrNullAs('text', Text.parse);
-    final template = parser.getSingleChildOrNullAs('template', Template.parse);
+    final template =
+        parser.getExternalPropertyOrNull('template', Template.parse);
     final properties = parser.getProperties();
 
     final polygon = parsePointList(parser, 'polygon');

--- a/packages/tiled/lib/src/tile_map_parser.dart
+++ b/packages/tiled/lib/src/tile_map_parser.dart
@@ -10,12 +10,19 @@ class TileMapParser {
   ///
   /// Accepts an optional list of external TsxProviders for external tilesets
   /// referenced in the map file.
-  static TiledMap parseTmx(String xml, {List<TsxProvider>? tsxList}) {
+  static TiledMap parseTmx(
+    String xml, {
+    List<TsxProvider>? tsxList,
+    Future<TsxProvider> Function(String key)? tsxProviderFunction,
+  }) {
     final xmlElement = XmlDocument.parse(xml).rootElement;
     if (xmlElement.name.local != 'map') {
       throw 'XML is not in TMX format';
     }
-    final parser = XmlParser(xmlElement);
+    final parser = XmlParser(
+      xmlElement,
+      tsxProviderFunction: tsxProviderFunction,
+    );
     return TiledMap.parse(parser, tsxList: tsxList);
   }
 }

--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -145,6 +145,7 @@ class TiledMap {
     return TileMapParser.parseTmx(
       contents,
       tsxList: tsxProviders.isEmpty ? null : tsxProviders,
+      tsxProviderFunction: tsxProviderFunction,
     );
   }
 


### PR DESCRIPTION
# Description

<!-- Provide a description of what this PR is doing. 
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed. -->

Currently, `template` is parsed from a child node like this:
```
final template = parser.getSingleChildOrNullAs('template', Template.parse);
```
But according to the current Tiled format, `template` is not a child node anymore:
```
  <object id="31" template="card.tx" name="bank" gid="0" x="-256" y="736" rotation="0"/>
```
There is no place to load the template file as well.
So, it is never found, that's why the `template` field in a parsed `TiledObject` is always `null`. I believe it's related to the issue https://github.com/flame-engine/tiled.dart/issues/47.

The object `id` is also not required anymore:
```
<?xml version="1.0" encoding="UTF-8"?>
<template>
 <object width="288" height="416"/>
</template>
```

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require users of the Tiled Dart library to manually update their apps to
accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

Fixes #47 

<!-- Links -->
[issue database]: https://github.com/flame-engine/tiled.dart/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
