### PR TITLE
fix: support parsing empty tile terrain values

### DIFF
--- a/packages/tiled/lib/src/tileset/tile.dart
+++ b/packages/tiled/lib/src/tileset/tile.dart
@@ -24,7 +24,7 @@ class Tile {
   double probability;
 
   /// List of indexes of the terrain.
-  List<int> terrain;
+  List<int?> terrain;
 
   TiledImage? image;
   Layer? objectGroup;
@@ -60,7 +60,7 @@ class Tile {
           terrain: parser
                   .getStringOrNull('terrain')
                   ?.split(',')
-                  .map(int.parse)
+                  .map((str) => str.isEmpty ? null : int.parse(str))
                   .toList() ??
               [],
           image: parser.getSingleChildOrNullAs('image', TiledImage.parse),

--- a/packages/tiled/test/fixtures/map_with_empty_terrains.tmx
+++ b/packages/tiled/test/fixtures/map_with_empty_terrains.tmx
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="32" height="32" tilewidth="16" tileheight="16" nextobjectid="1">
+ <tileset firstgid="1" name="test tileset" tilewidth="16" tileheight="16" tilecount="256" columns="16">
+  <image source="tileset_16x16.png" width="256" height="256"/>
+  <terraintypes>
+   <terrain name="test bright" tile="2"/>
+   <terrain name="test normal" tile="50"/>
+   <terrain name="test dark" tile="98"/>
+  </terraintypes>
+  <tile id="0" terrain=",,,0"/>
+  <tile id="1" terrain="0,0,0,"/>
+  <tile id="2" terrain="0,0,,"/>
+  <tile id="3" terrain="0,0,,0"/>
+  <tile id="4" terrain=",,,0"/>
+  <tile id="5" terrain=",,0,"/>
+  <tile id="50" terrain="1,1,,"/>
+  <tile id="98" terrain="2,2,,"/>
+ </tileset>
+</map>

--- a/packages/tiled/test/parser_test.dart
+++ b/packages/tiled/test/parser_test.dart
@@ -373,6 +373,18 @@ void main() {
       );
     });
   });
+
+  group('Parser tiles', () {
+    test('support empty terrain values', () {
+      final xml = File('./test/fixtures/map_with_empty_terrains.tmx')
+          .readAsStringSync();
+      final tiledMap = TileMapParser.parseTmx(xml);
+
+      final tileset = tiledMap.tilesets.first;
+      final tile = tileset.tiles.first;
+      expect(tile.terrain, anyElement(isNull));
+    });
+  });
 }
 
 class CustomTsxProvider extends TsxProvider {


### PR DESCRIPTION
# Description

- adjust the parsing of the Tile.terrain list to support empty terrain values
- fix https://github.com/flame-engine/tiled.dart/issues/60

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

- https://github.com/flame-engine/tiled.dart/issues/60

<!-- Links -->
[issue database]: https://github.com/flame-engine/tiled.dart/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
