### PR TITLE
feat: Add convenience method for getting images in each layer

### DIFF
--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -219,6 +219,26 @@ class TiledMap {
     return imageSet.toList();
   }
 
+  List<TiledImage> getImagesInLayer(TileLayer layer) {
+    final usedTilesets = <Tileset>{};
+    final inspectedGids = <int>{};
+    const emptyTile = 0;
+    layer.tileData?.forEach((ty) {
+      ty.forEach((gid) {
+        if (gid.tile == emptyTile || inspectedGids.contains(gid.tile)) {
+          return;
+        }
+        inspectedGids.add(gid.tile);
+        usedTilesets.add(tilesetByTileGId(gid.tile));
+      });
+    });
+
+    return usedTilesets
+        .map((e) => [e.image, ...e.tiles.map((e) => e.image)].whereNotNull())
+        .expand((images) => images)
+        .toList();
+  }
+
   /// Finds the first layer with the matching [name], or throw an
   /// [ArgumentError] if one cannot be found.
   /// Will search recursively through [Group] children.

--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -219,24 +219,32 @@ class TiledMap {
     return imageSet.toList();
   }
 
-  List<TiledImage> getImagesInLayer(TileLayer layer) {
-    final usedTilesets = <Tileset>{};
-    final inspectedGids = <int>{};
-    const emptyTile = 0;
-    layer.tileData?.forEach((ty) {
-      ty.forEach((gid) {
-        if (gid.tile == emptyTile || inspectedGids.contains(gid.tile)) {
-          return;
-        }
-        inspectedGids.add(gid.tile);
-        usedTilesets.add(tilesetByTileGId(gid.tile));
+  List<TiledImage> collectImagesInLayer(Layer layer) {
+    if (layer is ImageLayer) {
+      return [layer.image];
+    } else if (layer is Group) {
+      return layer.layers.map(collectImagesInLayer).expand((e) => e).toList();
+    } else if (layer is TileLayer) {
+      final usedTilesets = <Tileset>{};
+      final inspectedGids = <int>{};
+      const emptyTile = 0;
+      layer.tileData?.forEach((ty) {
+        ty.forEach((gid) {
+          if (gid.tile == emptyTile || inspectedGids.contains(gid.tile)) {
+            return;
+          }
+          inspectedGids.add(gid.tile);
+          usedTilesets.add(tilesetByTileGId(gid.tile));
+        });
       });
-    });
 
-    return usedTilesets
-        .map((e) => [e.image, ...e.tiles.map((e) => e.image)].whereNotNull())
-        .expand((images) => images)
-        .toList();
+      return usedTilesets
+          .map((e) => [e.image, ...e.tiles.map((e) => e.image)].whereNotNull())
+          .expand((images) => images)
+          .toList();
+    }
+
+    return [];
   }
 
   /// Finds the first layer with the matching [name], or throw an

--- a/packages/tiled/test/map_test.dart
+++ b/packages/tiled/test/map_test.dart
@@ -151,6 +151,128 @@ void main() {
     });
   });
 
+  group('Map.collectImagesInLayer', () {
+    late TiledMap map;
+    setUp(() {
+      map = TiledMap(
+        width: 2,
+        height: 2,
+        tileWidth: 8,
+        tileHeight: 8,
+        layers: [
+          TileLayer(
+            name: 'tile layer 1',
+            width: 2,
+            height: 2,
+            data: [1, 0, 2, 0],
+          ),
+          Group(
+            name: 'group layer 1',
+            layers: [
+              TileLayer(
+                name: 'group - tile layer 1',
+                width: 2,
+                height: 2,
+                data: [1, 2, 3, 0],
+              ),
+              TileLayer(
+                name: 'group - tile layer 2',
+                width: 2,
+                height: 2,
+                data: [5, 0, 0, 0],
+              ),
+            ],
+          ),
+          ImageLayer(
+            name: 'image layer 1',
+            image: const TiledImage(source: 'image_layer.png'),
+            repeatX: false,
+            repeatY: false,
+          ),
+          ObjectGroup(name: 'object layer 1', objects: []),
+        ],
+        tilesets: [
+          Tileset(
+            name: 'TileSet_1',
+            image: const TiledImage(source: 'tileset_1.png'),
+            firstGid: 1,
+            columns: 1,
+            tileCount: 2,
+            tiles: [
+              Tile(localId: 0),
+              Tile(localId: 1),
+            ],
+          ),
+          Tileset(
+            name: 'TileSet_2',
+            image: const TiledImage(source: 'tileset_2.png'),
+            firstGid: 3,
+            columns: 1,
+            tileCount: 2,
+            tiles: [
+              Tile(localId: 0),
+              Tile(localId: 1),
+            ],
+          ),
+          Tileset(
+            name: 'TileSet_3',
+            image: const TiledImage(source: 'tileset_3.png'),
+            firstGid: 5,
+            columns: 1,
+            tileCount: 2,
+            tiles: [
+              Tile(localId: 0),
+              Tile(localId: 1),
+            ],
+          ),
+        ],
+      );
+    });
+
+    test('gets images only in use on each TileLayer', () {
+      final tileLayer1 = map.layerByName('tile layer 1');
+      final tileLayer2 = map.layerByName('group - tile layer 1');
+
+      final images1 = map.collectImagesInLayer(tileLayer1);
+      final images2 = map.collectImagesInLayer(tileLayer2);
+
+      expect(images1, hasLength(1));
+      expect(images1[0].source, equals('tileset_1.png'));
+
+      expect(images2, hasLength(2));
+      expect(images2[0].source, equals('tileset_1.png'));
+      expect(images2[1].source, equals('tileset_2.png'));
+    });
+
+    test('gets all images recursively in the Group', () {
+      final tileLayerInsideGroup = map.layerByName('group layer 1');
+
+      final images3 = map.collectImagesInLayer(tileLayerInsideGroup);
+
+      expect(images3, hasLength(3));
+      expect(images3[0].source, equals('tileset_1.png'));
+      expect(images3[1].source, equals('tileset_2.png'));
+      expect(images3[2].source, equals('tileset_3.png'));
+    });
+
+    test('gets a image in the ImageLayer', () {
+      final imageLayer = map.layerByName('image layer 1');
+
+      final images = map.collectImagesInLayer(imageLayer);
+
+      expect(images, hasLength(1));
+      expect(images[0].source, equals('image_layer.png'));
+    });
+
+    test('gets no image in the ObjectLayer', () {
+      final imageLayer = map.layerByName('object layer 1');
+
+      final images = map.collectImagesInLayer(imageLayer);
+
+      expect(images, hasLength(0));
+    });
+  });
+
   group('Map.getTileSet', () {
     late TiledMap map;
     final tileset = Tileset(


### PR DESCRIPTION
# Description

This PR adds the convenience method to the TiledMap that gets all TiledImage in the specific layer.

If the layer is Group, the method gets all images in the group recursively.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require users of the Tiled Dart library to manually update their apps to
accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

N/A

<!-- Links -->
[issue database]: https://github.com/flame-engine/tiled.dart/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
