### PR TITLE
feat: Omit TiledImage without source from TiledMap.tiledImages

### DIFF
--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -205,17 +205,22 @@ class TiledMap {
     final imageSet = <TiledImage>{};
     for (var i = 0; i < tilesets.length; ++i) {
       final image = tilesets[i].image;
-      if (image != null) {
-        imageSet.add(image);
+      if (image?.source != null) {
+        imageSet.add(image!);
       }
       for (var j = 0; j < tilesets[i].tiles.length; ++j) {
         final image = tilesets[i].tiles[j].image;
-        if (image != null) {
-          imageSet.add(image);
+        if (image?.source != null) {
+          imageSet.add(image!);
         }
       }
     }
-    imageSet.addAll(layers.whereType<ImageLayer>().map((e) => e.image));
+    imageSet.addAll(
+      layers
+          .whereType<ImageLayer>()
+          .map((e) => e.image)
+          .where((e) => e.source != null),
+    );
     return imageSet.toList();
   }
 

--- a/packages/tiled/test/map_test.dart
+++ b/packages/tiled/test/map_test.dart
@@ -287,6 +287,70 @@ void main() {
     });
   });
 
+  group('Map.tiledImages', () {
+    late TiledMap map;
+    setUp(() {
+      map = TiledMap(
+        width: 10,
+        height: 10,
+        tileWidth: 16,
+        tileHeight: 16,
+        layers: [
+          ImageLayer(
+            name: 'image layer 1',
+            image: const TiledImage(),
+            repeatX: false,
+            repeatY: false,
+          ),
+          ImageLayer(
+            name: 'image layer 2',
+            image: const TiledImage(source: 'image_layer_2.png'),
+            repeatX: false,
+            repeatY: false,
+          ),
+        ],
+        tilesets: [
+          Tileset(
+            name: 'tileset 1',
+            image: const TiledImage(source: 'tileset_1.png'),
+          ),
+          Tileset(
+            name: 'tileset 2',
+            image: const TiledImage(),
+          ),
+          Tileset(
+            name: 'tileset 3',
+            tiles: [
+              Tile(
+                localId: 0,
+                image: const TiledImage(source: 'tile_0.png'),
+              ),
+              Tile(
+                localId: 1,
+                image: const TiledImage(),
+              ),
+            ],
+          )
+        ],
+      );
+    });
+    test('returns images with source', () {
+      final imageSources = map.tiledImages().map((e) => e.source);
+
+      expect(imageSources, hasLength(3));
+      expect(
+        imageSources,
+        containsAll(
+          <String>[
+            'image_layer_2.png',
+            'tileset_1.png',
+            'tile_0.png',
+          ],
+        ),
+      );
+    });
+  });
+
   group('Map.getTileSet', () {
     late TiledMap map;
     final tileset = Tileset(


### PR DESCRIPTION
# Description

- `TiledMap.tiledImages` returned `TiledImage` even if the source is null but now it returns only images with the source.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require users of the Tiled Dart library to manually update their apps to
accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Closes #67 

<!-- Links -->
[issue database]: https://github.com/flame-engine/tiled.dart/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
