### PR TITLE
fix: `ObjectAlignment` enum names

### DIFF
--- a/packages/tiled/lib/src/common/enums.dart
+++ b/packages/tiled/lib/src/common/enums.dart
@@ -386,7 +386,7 @@ enum ObjectAlignment {
   /// Returns the [ObjectAlignment] based on given [name].
   ///
   /// Throws an [ArgumentError] if no match is found.
-  static ObjectAlignment byName(String name) {
+  static ObjectAlignment fromName(String name) {
     for (final value in ObjectAlignment.values) {
       if (value.name == name) {
         return value;

--- a/packages/tiled/lib/src/common/enums.dart
+++ b/packages/tiled/lib/src/common/enums.dart
@@ -373,15 +373,15 @@ extension TilesetTypeParser on Parser {
 
 enum ObjectAlignment {
   unspecified,
-  topleft,
+  topLeft,
   top,
-  topright,
+  topRight,
   left,
   center,
   right,
-  bottomleft,
+  bottomLeft,
   bottom,
-  bottomright,
+  bottomRight,
 }
 
 extension ObjectAlignmentExtension on ObjectAlignment {
@@ -389,11 +389,11 @@ extension ObjectAlignmentExtension on ObjectAlignment {
     switch (this) {
       case ObjectAlignment.unspecified:
         return 'unspecified';
-      case ObjectAlignment.topleft:
+      case ObjectAlignment.topLeft:
         return 'topleft';
       case ObjectAlignment.top:
         return 'top';
-      case ObjectAlignment.topright:
+      case ObjectAlignment.topRight:
         return 'topright';
       case ObjectAlignment.left:
         return 'left';
@@ -401,11 +401,11 @@ extension ObjectAlignmentExtension on ObjectAlignment {
         return 'center';
       case ObjectAlignment.right:
         return 'right';
-      case ObjectAlignment.bottomleft:
+      case ObjectAlignment.bottomLeft:
         return 'bottomleft';
       case ObjectAlignment.bottom:
         return 'bottom';
-      case ObjectAlignment.bottomright:
+      case ObjectAlignment.bottomRight:
         return 'bottomright';
     }
   }

--- a/packages/tiled/lib/src/common/enums.dart
+++ b/packages/tiled/lib/src/common/enums.dart
@@ -381,7 +381,19 @@ enum ObjectAlignment {
   right,
   bottomLeft,
   bottom,
-  bottomRight,
+  bottomRight;
+
+  /// Returns the [ObjectAlignment] based on given [name].
+  ///
+  /// Throws an [ArgumentError] if no match is found.
+  static ObjectAlignment byName(String name) {
+    for (final value in ObjectAlignment.values) {
+      if (value.name == name) {
+        return value;
+      }
+    }
+    throw ArgumentError.value(name, 'name', 'No enum value with that name');
+  }
 }
 
 extension ObjectAlignmentExtension on ObjectAlignment {

--- a/packages/tiled/lib/src/common/enums.dart
+++ b/packages/tiled/lib/src/common/enums.dart
@@ -373,15 +373,15 @@ extension TilesetTypeParser on Parser {
 
 enum ObjectAlignment {
   unspecified,
-  topLeft,
+  topleft,
   top,
-  topRight,
+  topright,
   left,
   center,
   right,
-  bottomLeft,
+  bottomleft,
   bottom,
-  bottomRight,
+  bottomright,
 }
 
 extension ObjectAlignmentExtension on ObjectAlignment {
@@ -389,24 +389,24 @@ extension ObjectAlignmentExtension on ObjectAlignment {
     switch (this) {
       case ObjectAlignment.unspecified:
         return 'unspecified';
-      case ObjectAlignment.topLeft:
-        return 'topLeft';
+      case ObjectAlignment.topleft:
+        return 'topleft';
       case ObjectAlignment.top:
         return 'top';
-      case ObjectAlignment.topRight:
-        return 'topRight';
+      case ObjectAlignment.topright:
+        return 'topright';
       case ObjectAlignment.left:
         return 'left';
       case ObjectAlignment.center:
         return 'center';
       case ObjectAlignment.right:
         return 'right';
-      case ObjectAlignment.bottomLeft:
-        return 'bottomLeft';
+      case ObjectAlignment.bottomleft:
+        return 'bottomleft';
       case ObjectAlignment.bottom:
         return 'bottom';
-      case ObjectAlignment.bottomRight:
-        return 'bottomRight';
+      case ObjectAlignment.bottomright:
+        return 'bottomright';
     }
   }
 }

--- a/packages/tiled/lib/src/common/flips.dart
+++ b/packages/tiled/lib/src/common/flips.dart
@@ -6,14 +6,20 @@ class Flips {
   final bool diagonally;
   final bool antiDiagonally;
 
-  const Flips(
-    this.horizontally,
-    this.vertically,
-    this.diagonally,
-    this.antiDiagonally,
-  );
+  const Flips({
+    required this.horizontally,
+    required this.vertically,
+    required this.diagonally,
+    required this.antiDiagonally,
+  });
 
-  const Flips.defaults() : this(false, false, false, false);
+  const Flips.defaults()
+      : this(
+          horizontally: false,
+          vertically: false,
+          diagonally: false,
+          antiDiagonally: false,
+        );
 
   Flips copyWith({
     bool? horizontally,
@@ -22,10 +28,10 @@ class Flips {
     bool? antiDiagonally,
   }) {
     return Flips(
-      horizontally ?? this.horizontally,
-      vertically ?? this.vertically,
-      diagonally ?? this.diagonally,
-      antiDiagonally ?? this.antiDiagonally,
+      horizontally: horizontally ?? this.horizontally,
+      vertically: vertically ?? this.vertically,
+      diagonally: diagonally ?? this.diagonally,
+      antiDiagonally: antiDiagonally ?? this.antiDiagonally,
     );
   }
 }

--- a/packages/tiled/lib/src/common/gid.dart
+++ b/packages/tiled/lib/src/common/gid.dart
@@ -60,10 +60,10 @@ class Gid {
             flippedDiagonallyFlag |
             flippedAntiDiagonallyFlag);
     final flip = Flips(
-      flippedHorizontally,
-      flippedVertically,
-      flippedDiagonally,
-      flippedAntiDiagonally,
+      horizontally: flippedHorizontally,
+      vertically: flippedVertically,
+      diagonally: flippedDiagonally,
+      antiDiagonally: flippedAntiDiagonally,
     );
     return Gid(tileId, flip);
   }

--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -93,9 +93,9 @@ abstract class Layer {
   CustomProperties properties;
 
   Layer({
-    this.id,
     required this.name,
     required this.type,
+    this.id,
     this.class_,
     this.x = 0,
     this.y = 0,
@@ -298,7 +298,7 @@ abstract class Layer {
         }
         final text = xml.element.children.first;
         if (text is XmlText) {
-          return text.text;
+          return text.value;
         }
         return null;
       },
@@ -380,8 +380,10 @@ class TileLayer extends Layer {
   List<List<Gid>>? tileData;
 
   TileLayer({
-    super.id,
     required super.name,
+    required this.width,
+    required this.height,
+    super.id,
     super.class_,
     super.x,
     super.y,
@@ -396,8 +398,6 @@ class TileLayer extends Layer {
     super.opacity,
     super.visible,
     super.properties,
-    required this.width,
-    required this.height,
     this.compression,
     this.encoding = FileEncoding.csv,
     this.chunks,
@@ -441,8 +441,9 @@ class ObjectGroup extends Layer {
   Color color;
 
   ObjectGroup({
-    super.id,
     required super.name,
+    required this.objects,
+    super.id,
     super.class_,
     super.x,
     super.y,
@@ -458,7 +459,6 @@ class ObjectGroup extends Layer {
     super.visible,
     super.properties,
     this.drawOrder = DrawOrder.topDown,
-    required this.objects,
     this.colorHex = defaultColorHex,
     this.color = defaultColor,
   }) : super(
@@ -487,8 +487,11 @@ class ImageLayer extends Layer {
   bool repeatY;
 
   ImageLayer({
-    super.id,
     required super.name,
+    required this.image,
+    required this.repeatX,
+    required this.repeatY,
+    super.id,
     super.class_,
     super.x,
     super.y,
@@ -503,9 +506,6 @@ class ImageLayer extends Layer {
     super.opacity,
     super.visible,
     super.properties,
-    required this.image,
-    required this.repeatX,
-    required this.repeatY,
     this.transparentColorHex,
     this.transparentColor,
   }) : super(
@@ -518,8 +518,9 @@ class Group extends Layer {
   List<Layer> layers;
 
   Group({
-    super.id,
     required super.name,
+    required this.layers,
+    super.id,
     super.class_,
     super.x,
     super.y,
@@ -534,7 +535,6 @@ class Group extends Layer {
     super.opacity,
     super.visible,
     super.properties,
-    required this.layers,
   }) : super(
           type: LayerType.imageLayer,
         );

--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -97,14 +97,14 @@ class TiledMap {
   StaggerIndex? staggerIndex;
 
   TiledMap({
+    required this.width,
+    required this.height,
+    required this.tileWidth,
+    required this.tileHeight,
     this.type = TileMapType.map,
     this.version = '1.0',
     this.tiledVersion,
-    required this.width,
-    required this.height,
     this.infinite = false,
-    required this.tileWidth,
-    required this.tileHeight,
     this.tilesets = const [],
     this.layers = const [],
     this.backgroundColorHex,

--- a/packages/tiled/lib/src/tileset/tileset.dart
+++ b/packages/tiled/lib/src/tileset/tileset.dart
@@ -109,7 +109,7 @@ class Tileset {
     final firstGid = parser.getIntOrNull('firstgid');
     final margin = parser.getInt('margin', defaults: 0);
     final name = parser.getStringOrNull('name');
-    final objectAlignment = ObjectAlignment.values.byName(
+    final objectAlignment = ObjectAlignment.byName(
       parser.getString('objectalignment', defaults: 'unspecified'),
     );
     final source = parser.getStringOrNull('source');

--- a/packages/tiled/lib/src/tileset/tileset.dart
+++ b/packages/tiled/lib/src/tileset/tileset.dart
@@ -109,7 +109,7 @@ class Tileset {
     final firstGid = parser.getIntOrNull('firstgid');
     final margin = parser.getInt('margin', defaults: 0);
     final name = parser.getStringOrNull('name');
-    final objectAlignment = ObjectAlignment.byName(
+    final objectAlignment = ObjectAlignment.fromName(
       parser.getString('objectalignment', defaults: 'unspecified'),
     );
     final source = parser.getStringOrNull('source');

--- a/packages/tiled/pubspec.yaml
+++ b/packages/tiled/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^6.0.1
-  flame_lint: ^0.2.0
+  flame_lint: ^1.1.1
   flutter_test:
     sdk: flutter

--- a/packages/tiled/test/map_test.dart
+++ b/packages/tiled/test/map_test.dart
@@ -330,7 +330,7 @@ void main() {
                 image: const TiledImage(),
               ),
             ],
-          )
+          ),
         ],
       );
     });

--- a/packages/tiled/test/object_alignment_test.dart
+++ b/packages/tiled/test/object_alignment_test.dart
@@ -5,19 +5,19 @@ void main() {
   group('ObjectAlignment', () {
     test('ObjectAlignment.byName', () {
       expect(
-        ObjectAlignment.byName('unspecified'),
+        ObjectAlignment.fromName('unspecified'),
         ObjectAlignment.unspecified,
       );
-      expect(ObjectAlignment.byName('topleft'), ObjectAlignment.topLeft);
-      expect(ObjectAlignment.byName('top'), ObjectAlignment.top);
-      expect(ObjectAlignment.byName('topright'), ObjectAlignment.topRight);
-      expect(ObjectAlignment.byName('left'), ObjectAlignment.left);
-      expect(ObjectAlignment.byName('center'), ObjectAlignment.center);
-      expect(ObjectAlignment.byName('right'), ObjectAlignment.right);
-      expect(ObjectAlignment.byName('bottomleft'), ObjectAlignment.bottomLeft);
-      expect(ObjectAlignment.byName('bottom'), ObjectAlignment.bottom);
+      expect(ObjectAlignment.fromName('topleft'), ObjectAlignment.topLeft);
+      expect(ObjectAlignment.fromName('top'), ObjectAlignment.top);
+      expect(ObjectAlignment.fromName('topright'), ObjectAlignment.topRight);
+      expect(ObjectAlignment.fromName('left'), ObjectAlignment.left);
+      expect(ObjectAlignment.fromName('center'), ObjectAlignment.center);
+      expect(ObjectAlignment.fromName('right'), ObjectAlignment.right);
+      expect(ObjectAlignment.fromName('bottomleft'), ObjectAlignment.bottomLeft);
+      expect(ObjectAlignment.fromName('bottom'), ObjectAlignment.bottom);
       expect(
-        ObjectAlignment.byName('bottomright'),
+        ObjectAlignment.fromName('bottomright'),
         ObjectAlignment.bottomRight,
       );
     });

--- a/packages/tiled/test/object_alignment_test.dart
+++ b/packages/tiled/test/object_alignment_test.dart
@@ -14,7 +14,10 @@ void main() {
       expect(ObjectAlignment.fromName('left'), ObjectAlignment.left);
       expect(ObjectAlignment.fromName('center'), ObjectAlignment.center);
       expect(ObjectAlignment.fromName('right'), ObjectAlignment.right);
-      expect(ObjectAlignment.fromName('bottomleft'), ObjectAlignment.bottomLeft);
+      expect(
+        ObjectAlignment.fromName('bottomleft'),
+        ObjectAlignment.bottomLeft,
+      );
       expect(ObjectAlignment.fromName('bottom'), ObjectAlignment.bottom);
       expect(
         ObjectAlignment.fromName('bottomright'),

--- a/packages/tiled/test/object_alignment_test.dart
+++ b/packages/tiled/test/object_alignment_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tiled/tiled.dart';
+
+void main() {
+  group('ObjectAlignment', () {
+    test('ObjectAlignment.byName', () {
+      expect(
+        ObjectAlignment.byName('unspecified'),
+        ObjectAlignment.unspecified,
+      );
+      expect(ObjectAlignment.byName('topleft'), ObjectAlignment.topLeft);
+      expect(ObjectAlignment.byName('top'), ObjectAlignment.top);
+      expect(ObjectAlignment.byName('topright'), ObjectAlignment.topRight);
+      expect(ObjectAlignment.byName('left'), ObjectAlignment.left);
+      expect(ObjectAlignment.byName('center'), ObjectAlignment.center);
+      expect(ObjectAlignment.byName('right'), ObjectAlignment.right);
+      expect(ObjectAlignment.byName('bottomleft'), ObjectAlignment.bottomLeft);
+      expect(ObjectAlignment.byName('bottom'), ObjectAlignment.bottom);
+      expect(
+        ObjectAlignment.byName('bottomright'),
+        ObjectAlignment.bottomRight,
+      );
+    });
+  });
+}

--- a/packages/tiled/test/tileset_test.dart
+++ b/packages/tiled/test/tileset_test.dart
@@ -57,7 +57,9 @@ void main() {
     test(
       'first objectgroup object = ellipsis',
       () => expect(
-        ((tileset.tiles.first.objectGroup as ObjectGroup?)!.objects.first)
+        (tileset.tiles.first.objectGroup as ObjectGroup?)!
+            .objects
+            .first
             .isEllipse,
         true,
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,0 @@
-name: tiled_workspace
-
-environment:
-  sdk: ">=3.0.0 <4.0.0"
-
-dev_dependencies:
-  melos: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,7 @@
+name: tiled_workspace
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dev_dependencies:
+  melos: ^3.0.0


### PR DESCRIPTION
# Description

Name of some of the enum values of `ObjectAlignment` were not matching the values from Tiled. As a result, tilesets with `topLeft`, `topRight`, `bottomLeft` and `bottomRight` alignment couldn't be parsed. https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tmx-tileset

![image](https://github.com/flame-engine/tiled.dart/assets/33748002/08c51540-4c1a-4890-ad83-30030c7aed2a)

Another problem that was discovered after fixing the names was with the `byName` method from the `EnumByName` extension. That method was not using names from `ObjectAlignmentExtension` that Tiled defines. To fix that, this PR adds a `byName` static method for `ObjectAlignment` which uses the correct names.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.


## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.


## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/tiled.dart/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
