### PR TITLE
fix: Fixed parsing of multiline text from ObjectGroup.

### DIFF
--- a/packages/tiled/lib/src/objects/text.dart
+++ b/packages/tiled/lib/src/objects/text.dart
@@ -74,7 +74,8 @@ class Text {
           fontFamily: parser.getString('fontFamily', defaults: 'sans-serif'),
           pixelSize: parser.getInt('pixelSize', defaults: 16),
           color: parser.getString('color', defaults: '#000000'),
-          text: parser.getString('text', defaults: ''),
+          text: parser.getInnerTextOrNull() ??
+              parser.getString('text', defaults: ''),
           hAlign: parser.getHAlign('hAlign', defaults: HAlign.left),
           vAlign: parser.getVAlign('vAlign', defaults: VAlign.top),
           bold: parser.getBool('bold', defaults: false),

--- a/packages/tiled/lib/src/parser.dart
+++ b/packages/tiled/lib/src/parser.dart
@@ -12,6 +12,10 @@ class XmlParser extends Parser {
   XmlParser(this.element);
 
   @override
+  String? getInnerTextOrNull() =>
+      element.innerText.isEmpty ? null : element.innerText;
+
+  @override
   String? getStringOrNull(String name, {String? defaults}) {
     return element.getAttribute(name) ?? defaults;
   }
@@ -47,6 +51,9 @@ class JsonParser extends Parser {
   JsonParser(this.json);
 
   @override
+  String? getInnerTextOrNull() => null;
+
+  @override
   String? getStringOrNull(String name, {String? defaults}) {
     return json[name]?.toString() ?? defaults;
   }
@@ -75,6 +82,8 @@ class JsonParser extends Parser {
 }
 
 abstract class Parser {
+  String? getInnerTextOrNull();
+
   String? getStringOrNull(String name, {String? defaults});
 
   List<Parser> getChildren(String name);

--- a/packages/tiled/test/parser_test.dart
+++ b/packages/tiled/test/parser_test.dart
@@ -88,7 +88,9 @@ void main() {
             equals('test_value'),
           );
           expect(
-            properties.getValue<String>('multiline string'),
+            properties
+                .getValue<String>('multiline string')
+                ?.replaceAll('\r\n', '\n'),
             equals('Hello,\nWorld'),
           );
           expect(

--- a/packages/tiled/test/parser_test.dart
+++ b/packages/tiled/test/parser_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:math' show Rectangle;
 import 'dart:ui';
 
+import 'package:collection/collection.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tiled/tiled.dart';
 import 'package:xml/xml.dart';
@@ -236,6 +237,15 @@ void main() {
 
       test('has the right class_', () {
         expect(og.class_, equals('objectLayer1Class'));
+      });
+
+      test('has the right text object with ID 5', () {
+        final textObject = (og as ObjectGroup)
+            .objects
+            .firstWhereOrNull((element) => element.id == 5);
+        final text = textObject?.text;
+        expect(text?.wrap, equals(true));
+        expect(text?.text, equals('Hello World'));
       });
     });
   });


### PR DESCRIPTION
# Description

Fixed parsing of multiline text from ObjectGroup -> Object -> Text.

Also corrected a test for checking multiline properties in Windows.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
