### PR TITLE
fix: Data section of Layers was null (when loading from JSON)

### DIFF
--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -146,7 +146,7 @@ abstract class Layer {
         final width = parser.getInt('width');
         final height = parser.getInt('height');
         final dataNode = parser.formatSpecificParsing(
-          (json) => null, // data is just a string or list of int on JSON
+          (json) => json, // data is just a string or list of int on JSON
           (xml) => xml.getSingleChildOrNull('data'),
         );
         final compression = parser.getCompressionOrNull('compression') ??


### PR DESCRIPTION
# Description

I have loaded a JSON TiledMap File but the data sections of the Tilelayer's were always null.

Here is a simple JSON to test the loader with:

```json
{ "compressionlevel":-1,
 "height":25,
 "infinite":false,
 "layers":[
        {
         "compression":"zlib",
         "data":"eJzVV0kOxDAIa\/7\/6TmNVFVAsFlCkHrIDGZxw9LnmSPrdAAJsoSn2++tIsXfkdOpd5YtVtxMbh6MxN2NHCIxe3QRnQiHU\/iW\/DO5deXC3teq+DT+UBtdvVL73XtnLTyTQ4Q\/ti8i4s0NqXkUh\/rNijcDh7xLRq+qbqr6XAV\/aB9ksYhU7RZMzWfoWLoTZ3iWvmePjPqdwF\/2nfLav4m\/rHvA6i\/jHPXXtX9lvcPoLnOyhzJ2lvN\/1Ffl90xkLqN+LJ+euonsg9bDSnU\/sbDoOeo\/W7K+w1istmN6euBuxnT1aQYX9Snxo9XzjkO2Fnd9doftxL3x2rlzZ3rngXJ+iru\/De1cOR8le1\/+vLuHNdcq5tPXRydOs8Xyp9mZNNMkqbqDFbanSnaOkfnRKT9oHwEi",
         "encoding":"base64",
         "height":25,
         "id":1,
         "name":"main",
         "opacity":1,
         "type":"tilelayer",
         "visible":true,
         "width":80,
         "x":0,
         "y":0
        }],
 "nextlayerid":2,
 "nextobjectid":1,
 "orientation":"orthogonal",
 "renderorder":"right-down",
 "tiledversion":"1.8.2",
 "tileheight":8,
 "tilesets":[
        {
         "firstgid":1,
         "source":"world1.json"
        }],
 "tilewidth":8,
 "type":"map",
 "version":"1.8",
 "width":80
}
```