### PR TITLE
chore: Remove angle brackets from dartdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Dart Tiled library.
 
 ## Install from Dart Pub Repository
 
-To include the package as a depencency in your `pubspec.yaml`, run the following (or add it manually):
+To include the package as a dependency in your `pubspec.yaml`, run the following (or add it manually):
 
 ```sh
 dart pub add tiled
@@ -29,7 +29,7 @@ Load a TMX file into a string by any means, and then pass the string to TileMapP
     final TiledMap mapTmx = TileMapParser.parseTmx(tmxBody);
 ```
 
-If your tmx file includes a external tsx reference, you have to add a CustomParser
+If your tmx file includes an external tsx reference, you have to add a CustomParser
 ```dart
 class CustomTsxProvider extends TsxProvider {
   @override

--- a/packages/tiled/lib/src/chunk.dart
+++ b/packages/tiled/lib/src/chunk.dart
@@ -26,7 +26,7 @@ class Chunk {
   int width;
   int height;
 
-  /// This is not part of the tiled definitions; this is just a convenient
+  /// This is not part of the tiled definitions; this is just a convenience
   /// wrapper over the [data] field that simplifies two things:
   ///
   /// * represents the matrix as a matrix (`List<List<X>>`) instead of a flat

--- a/packages/tiled/lib/src/chunk.dart
+++ b/packages/tiled/lib/src/chunk.dart
@@ -3,7 +3,7 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <chunk>
+/// `<chunk>`
 ///
 /// * x: The x coordinate of the chunk in tiles.
 /// * y: The y coordinate of the chunk in tiles.
@@ -26,10 +26,11 @@ class Chunk {
   int width;
   int height;
 
-  /// This is not part of the tiled definitions; this is just a convinient
+  /// This is not part of the tiled definitions; this is just a convenient
   /// wrapper over the [data] field that simplifies two things:
   ///
-  /// * represents the matrix as a matrix (List<List<X>>) instead of a flat list
+  /// * represents the matrix as a matrix (`List<List<X>>`) instead of a flat
+  /// list
   /// * wraps the gid integer into the [Gid] class for easy access of properties
   List<List<Gid>> tileData;
 

--- a/packages/tiled/lib/src/common/frame.dart
+++ b/packages/tiled/lib/src/common/frame.dart
@@ -3,9 +3,9 @@ import 'package:tiled/src/parser.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <frame>
+/// `<frame>`
 ///
-/// * tileid: The local ID of a tile within the parent <tileset>.
+/// * tileid: The local ID of a tile within the parent `<tileset>`.
 /// * duration: How long (in milliseconds) this frame should be displayed
 ///   before advancing to the next frame.
 class Frame {

--- a/packages/tiled/lib/src/common/point.dart
+++ b/packages/tiled/lib/src/common/point.dart
@@ -3,7 +3,7 @@ import 'package:tiled/src/parser.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <point>
+/// `<point>`
 /// Used to mark an object as a point.
 /// The existing x and y attributes are used to determine the position of the
 /// point.

--- a/packages/tiled/lib/src/common/property.dart
+++ b/packages/tiled/lib/src/common/property.dart
@@ -5,7 +5,7 @@ import 'package:xml/xml.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <property>
+/// `<property>`
 /// * name: The name of the property.
 /// * type: The type of the property.
 ///   Can be string (default), int, float, bool, color, file or object
@@ -79,7 +79,7 @@ class Property<T> {
             return attrString;
           } else {
             // In tmx files, multi-line text property values can be stored
-            // inside the <property> node itself instead of in the 'value'
+            // inside the `<property>` node itself instead of in the 'value'
             // attribute
             return xml.element.innerText;
           }

--- a/packages/tiled/lib/src/common/property.dart
+++ b/packages/tiled/lib/src/common/property.dart
@@ -195,7 +195,7 @@ class IntProperty extends Property<int> {
   }) : super(type: PropertyType.int);
 }
 
-/// [value] is the double-percision floating-point number
+/// [value] is the double-precision floating-point number
 class FloatProperty extends Property<double> {
   FloatProperty({
     required super.name,

--- a/packages/tiled/lib/src/common/tiled_image.dart
+++ b/packages/tiled/lib/src/common/tiled_image.dart
@@ -4,7 +4,7 @@ import 'package:tiled/src/parser.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <image>
+/// `<image>`
 ///
 /// * format: Used for embedded images, in combination with a data child
 ///   element.

--- a/packages/tiled/lib/src/editor_setting/chunk_size.dart
+++ b/packages/tiled/lib/src/editor_setting/chunk_size.dart
@@ -3,7 +3,7 @@ import 'package:tiled/src/parser.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <chunksize>
+/// `<chunksize>`
 ///
 /// * width: The width of chunks used for infinite maps (default to 16).
 /// * height: The width of chunks used for infinite maps (default to 16).

--- a/packages/tiled/lib/src/editor_setting/editor_setting.dart
+++ b/packages/tiled/lib/src/editor_setting/editor_setting.dart
@@ -3,11 +3,11 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <editorsettings>
+/// `<editorsettings>`
 /// This element contains various editor-specific settings,
 /// which are generally not relevant when reading a map.
 ///
-/// Can contain: <chunksize>, <export>
+/// Can contain: `<chunksize>`, `<export>`
 class EditorSetting {
   ChunkSize? chunkSize;
   Export? export;

--- a/packages/tiled/lib/src/editor_setting/export.dart
+++ b/packages/tiled/lib/src/editor_setting/export.dart
@@ -3,7 +3,7 @@ import 'package:tiled/src/parser.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <export>
+/// `<export>`
 ///
 /// * target: The last file this map was exported to.
 /// * format: The short name of the last format this map was exported as.

--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -8,8 +8,8 @@ import 'package:xml/xml.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// All <tileset> tags shall occur before the first <layer> tag so that parsers
-/// may rely on having the tilesets before needing to resolve tiles.
+/// All `<tileset>` tags shall occur before the first `<layer>` tag so that
+/// parsers may rely on having the tilesets before needing to resolve tiles.
 ///
 /// * id: Unique ID of the layer. Each layer that added to a map gets a unique
 ///   id. Even if a layer is deleted, no layer ever gets the same ID.
@@ -36,7 +36,7 @@ import 'package:xml/xml.dart';
 /// * parallaxy: Vertical parallax factor for this layer.
 ///   Defaults to 1. (since 1.5)
 ///
-/// Can contain at most one: <properties>, <data>
+/// Can contain at most one: `<properties>`, `<data>`
 abstract class Layer {
   /// Incremental ID - unique across all layers
   int? id;

--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -377,10 +377,11 @@ class TileLayer extends Layer {
   /// See [tileData] for a better representation.
   List<int>? data;
 
-  /// This is not part of the tiled definitions; this is just a convinient
+  /// This is not part of the tiled definitions; this is just a convenience
   /// wrapper over the [data] field that simplifies two things:
   ///
-  /// * represents the matrix as a matrix (List<List<X>>) instead of a flat list
+  /// * represents the matrix as a matrix (`List<List<X>>`) instead of a flat
+  ///   list
   /// * wraps the gid integer into the [Gid] class for easy access of properties
   List<List<Gid>>? tileData;
 

--- a/packages/tiled/lib/src/objects/text.dart
+++ b/packages/tiled/lib/src/objects/text.dart
@@ -3,7 +3,7 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <text>
+/// `<text>`
 ///
 /// * fontfamily: The font family used (defaults to "sans-serif")
 /// * pixelsize: The size of the font in pixels (not using points, because

--- a/packages/tiled/lib/src/objects/tiled_object.dart
+++ b/packages/tiled/lib/src/objects/tiled_object.dart
@@ -42,7 +42,7 @@ import 'package:tiled/tiled.dart';
 /// priority, i.e. they will override the template properties.
 ///
 /// Can contain at most one: `<properties>`, `<ellipse>` (since 0.9),
-/// `<point>` (since 1.1), `<polygon>`, `<polyline>, `<text>` (since 1.0)
+/// `<point>` (since 1.1), `<polygon>`, `<polyline>`, `<text>` (since 1.0)
 class TiledObject {
   int id;
   String name;

--- a/packages/tiled/lib/src/objects/tiled_object.dart
+++ b/packages/tiled/lib/src/objects/tiled_object.dart
@@ -3,7 +3,7 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <object>
+/// `<object>`
 ///
 /// * id: Unique ID of the object. Each object that is placed on a map gets a
 ///   unique id. Even if an object was deleted, no object gets the same ID.
@@ -41,8 +41,8 @@ import 'package:tiled/tiled.dart';
 /// the specified template, properties saved with the object will have higher
 /// priority, i.e. they will override the template properties.
 ///
-/// Can contain at most one: <properties>, <ellipse> (since 0.9),
-/// <point> (since 1.1), <polygon>, <polyline>, <text> (since 1.0)
+/// Can contain at most one: `<properties>`, `<ellipse>` (since 0.9),
+/// `<point>` (since 1.1), `<polygon>`, `<polyline>, `<text> (since 1.0)
 class TiledObject {
   int id;
   String name;

--- a/packages/tiled/lib/src/objects/tiled_object.dart
+++ b/packages/tiled/lib/src/objects/tiled_object.dart
@@ -42,7 +42,7 @@ import 'package:tiled/tiled.dart';
 /// priority, i.e. they will override the template properties.
 ///
 /// Can contain at most one: `<properties>`, `<ellipse>` (since 0.9),
-/// `<point>` (since 1.1), `<polygon>`, `<polyline>, `<text> (since 1.0)
+/// `<point>` (since 1.1), `<polygon>`, `<polyline>, `<text>` (since 1.0)
 class TiledObject {
   int id;
   String name;

--- a/packages/tiled/lib/src/objects/tiled_object.dart
+++ b/packages/tiled/lib/src/objects/tiled_object.dart
@@ -109,7 +109,7 @@ class TiledObject {
     final gid = parser.getIntOrNull('gid');
     final name = parser.getString('name', defaults: '');
 
-    // Tiled 1.9 and above versions running in compatibilty mode set to
+    // Tiled 1.9 and above versions running in compatibility mode set to
     // "Tiled 1.8" will still write out "Class" property as "type". So try both
     // before using default value.
     final type = parser.getString(

--- a/packages/tiled/lib/src/template.dart
+++ b/packages/tiled/lib/src/template.dart
@@ -3,7 +3,7 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <template>
+/// `<template>`
 ///
 /// The template root element contains the saved map object and a tileset
 /// element that points to an external tileset, if the object is a tile object.
@@ -18,7 +18,7 @@ import 'package:tiled/tiled.dart';
 ///   </template>
 /// ```
 ///
-/// Can contain at most one: <tileset>, <object>
+/// Can contain at most one: `<tileset>`, `<object>`
 class Template {
   Tileset? tileSet;
   TiledObject? object;

--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -58,7 +58,7 @@ import 'package:xml/xml.dart';
 /// Can contain at most one: `<properties>`
 ///
 /// Can contain any number: `<tileset>`, `<layer>`, `<objectgroup>`,
-/// `<imagelayer>`, `<group> (since 1.0), `<editorsettings>` (since 1.3)
+/// `<imagelayer>`, `<group>` (since 1.0), `<editorsettings>` (since 1.3)
 class TiledMap {
   TileMapType type;
   String version;

--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -55,10 +55,10 @@ import 'package:xml/xml.dart';
 ///
 /// The staggered orientation refers to an isometric map using staggered axes.
 ///
-/// Can contain at most one: `<properties>
+/// Can contain at most one: `<properties>`
 ///
-/// Can contain any number: `<tileset>, `<layer>, `<objectgroup>, `<imagelayer>,
-/// `<group> (since 1.0), `<editorsettings> (since 1.3)
+/// Can contain any number: `<tileset>`, `<layer>`, `<objectgroup>`,
+/// `<imagelayer>`, `<group> (since 1.0), `<editorsettings>` (since 1.3)
 class TiledMap {
   TileMapType type;
   String version;

--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -7,7 +7,7 @@ import 'package:xml/xml.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <map>
+/// `<map>`
 ///
 /// * version: The TMX format version. Was “1.0” so far, and will be incremented
 ///   to match minor Tiled releases.
@@ -55,10 +55,10 @@ import 'package:xml/xml.dart';
 ///
 /// The staggered orientation refers to an isometric map using staggered axes.
 ///
-/// Can contain at most one: <properties>
+/// Can contain at most one: `<properties>
 ///
-/// Can contain any number: <tileset>, <layer>, <objectgroup>, <imagelayer>,
-/// <group> (since 1.0), <editorsettings> (since 1.3)
+/// Can contain any number: `<tileset>, `<layer>, `<objectgroup>, `<imagelayer>,
+/// `<group> (since 1.0), `<editorsettings> (since 1.3)
 class TiledMap {
   TileMapType type;
   String version;

--- a/packages/tiled/lib/src/tileset/grid.dart
+++ b/packages/tiled/lib/src/tileset/grid.dart
@@ -3,7 +3,7 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <grid>
+/// `<grid>`
 ///
 /// * orientation: Orientation of the grid for the tiles in this tileset
 ///   (orthogonal or isometric, defaults to orthogonal)

--- a/packages/tiled/lib/src/tileset/terrain.dart
+++ b/packages/tiled/lib/src/tileset/terrain.dart
@@ -3,12 +3,12 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <terrain>
+/// `<terrain>`
 ///
 /// * name: The name of the terrain type.
 /// * tile: The local tile-id of the tile that represents the terrain visually.
 ///
-/// Can contain at most one: <properties>
+/// Can contain at most one: `<properties>`
 class Terrain {
   String name;
   int tile;

--- a/packages/tiled/lib/src/tileset/tile.dart
+++ b/packages/tiled/lib/src/tileset/tile.dart
@@ -5,7 +5,7 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <tile>
+/// `<tile>`
 ///
 /// * id: The local tile ID within its tileset.
 /// * type: The type of the tile. Refers to an object type and is used by tile
@@ -18,8 +18,8 @@ import 'package:tiled/tiled.dart';
 ///   chosen when it competes with others while editing with the terrain tool.
 ///   (defaults to 0)
 ///
-/// Can contain at most one: <properties>, <image> (since 0.9), <objectgroup>,
-/// <animation>.
+/// Can contain at most one: `<properties>`, `<image>` (since 0.9),
+/// `<objectgroup>`, `<animation>`.
 class Tile {
   int localId;
   String? type;

--- a/packages/tiled/lib/src/tileset/tile_offset.dart
+++ b/packages/tiled/lib/src/tileset/tile_offset.dart
@@ -3,7 +3,7 @@ import 'package:tiled/src/parser.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <tileoffset>
+/// `<tileoffset>`
 ///
 /// x: Horizontal offset in pixels. (defaults to 0)
 /// y: Vertical offset in pixels (positive is down, defaults to 0)

--- a/packages/tiled/lib/src/tileset/tileset.dart
+++ b/packages/tiled/lib/src/tileset/tileset.dart
@@ -5,7 +5,7 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <tileset>
+/// `<tileset>`
 ///
 /// * firstgid: The first global tile ID of this tileset (this global ID maps
 ///   to the first tile in this tileset).
@@ -31,19 +31,19 @@ import 'package:tiled/tiled.dart';
 ///   compatibility reasons. When unspecified, tile objects use bottomleft in
 ///   orthogonal mode and bottom in isometric mode. (since 1.4)
 ///
-/// If there are multiple <tileset> elements, they are in ascending order of
+/// If there are multiple `<tileset>` elements, they are in ascending order of
 /// their firstgid attribute. The first tileset always has a firstgid value of
 /// 1. Since Tiled 0.15, image collection tilesets do not necessarily number
 /// their tiles consecutively since gaps can occur when removing tiles.
 ///
-/// Image collection tilesets have no <image> tag. Instead, each tile has an
-/// <image> tag.
+/// Image collection tilesets have no `<image>` tag. Instead, each tile has an
+/// `<image>` tag.
 ///
-/// Can contain at most one: <image>, <tileoffset>, <grid> (since 1.0),
-/// <properties>, <terraintypes>, <wangsets> (since 1.1), <transformations>
-/// (since 1.5)
+/// Can contain at most one: `<image>`, `<tileoffset>`, `<grid>` (since 1.0),
+/// `<properties>`, `<terraintypes>`, `<wangsets>` (since 1.1),
+/// `<transformations>` (since 1.5)
 ///
-/// Can contain any number: <tile>
+/// Can contain any number: `<tile>`
 class Tileset {
   int? firstGid;
   String? source;

--- a/packages/tiled/lib/src/tileset/tileset.dart
+++ b/packages/tiled/lib/src/tileset/tileset.dart
@@ -11,9 +11,9 @@ import 'package:tiled/tiled.dart';
 ///   to the first tile in this tileset).
 /// * source: If this tileset is stored in an external TSX (Tile Set XML) file,
 ///   this attribute refers to that file. That TSX file has the same structure
-///   as the <tileset> element described here. (There is the firstgid attribute
-///   missing and this source attribute is also not there. These two attributes
-///   are kept in the TMX map, since they are map specific.)
+///   as the `<tileset>` element described here. (There is the firstgid
+///   attribute missing and this source attribute is also not there. These two
+///   attributes are kept in the TMX map, since they are map specific.)
 /// * name: The name of this tileset.
 /// * tilewidth: The (maximum) width of the tiles in this tileset.
 /// * tileheight: The (maximum) height of the tiles in this tileset.

--- a/packages/tiled/lib/src/tileset/wang/wang_color.dart
+++ b/packages/tiled/lib/src/tileset/wang/wang_color.dart
@@ -3,7 +3,7 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <wangcolor>
+/// `<wangcolor>`
 /// A color that can be used to define the corner and/or edge of a Wang tile.
 ///
 /// * name: The name of this color.
@@ -12,7 +12,7 @@ import 'package:tiled/tiled.dart';
 /// * probability: The relative probability that this color is chosen over
 ///   others in case of multiple options. (defaults to 0)
 ///
-/// Can contain at most one: <properties>
+/// Can contain at most one: `<properties>`
 class WangColor {
   String name;
   String color;

--- a/packages/tiled/lib/src/tileset/wang/wang_set.dart
+++ b/packages/tiled/lib/src/tileset/wang/wang_set.dart
@@ -3,18 +3,18 @@ import 'package:tiled/tiled.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <wangset>
+/// `<wangset>`
 ///
 /// Defines a list of corner colors and a list of edge colors, and any number
 /// of Wang tiles using these colors.
 ///
 /// name: The name of the Wang set.
 /// tile: The tile ID of the tile representing this Wang set.
-/// Can contain at most one: <properties>
+/// Can contain at most one: `<properties>`
 ///
-/// Can contain up to 255: <wangcolor> (since Tiled 1.5)
+/// Can contain up to 255: `<wangcolor>` (since Tiled 1.5)
 ///
-/// Can contain any number: <wangtile>
+/// Can contain any number: `<wangtile>`
 class WangSet {
   String name;
   int tile;

--- a/packages/tiled/lib/src/tileset/wang/wang_tile.dart
+++ b/packages/tiled/lib/src/tileset/wang/wang_tile.dart
@@ -5,7 +5,7 @@ import 'package:tiled/src/parser.dart';
 /// Below is Tiled's documentation about how this structure is represented
 /// on XML files:
 ///
-/// <wangtile>
+/// `<wangtile>`
 ///
 /// Defines a Wang tile, by referring to a tile in the tileset and associating
 /// it with a certain Wang ID.

--- a/packages/tiled/lib/src/tsx_provider.dart
+++ b/packages/tiled/lib/src/tsx_provider.dart
@@ -10,7 +10,7 @@ abstract class TsxProvider {
   Parser getSource(String filename);
 
   /// Used when provider implementations cache the data. Returns the cached
-  /// data for the exernal tileset.
+  /// data for the external tileset.
   Parser? getCachedSource();
 
   /// Parses a file returning a [TsxProvider].

--- a/packages/tiled/test/map_test.dart
+++ b/packages/tiled/test/map_test.dart
@@ -125,14 +125,14 @@ void main() {
 
     test('errors if tile phrase is not in the correct format', () {
       expect(
-        () => map.tileByPhrase('Nonexistant Tile'),
+        () => map.tileByPhrase('Nonexistent Tile'),
         throwsArgumentError,
       );
     });
 
     test('errors if tileset is not present', () {
       expect(
-        () => map.tileByPhrase('Nonexistant Tile|0'),
+        () => map.tileByPhrase('Nonexistent Tile|0'),
         throwsArgumentError,
       );
     });


### PR DESCRIPTION
# Description

Since angle brackets represent html in dartdocs now they should be surrounded by backticks if not meant as html.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require users of the Tiled Dart library to manually update their apps to
accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/tiled.dart/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
