### PR TITLE
fix: Object layer parsing for JSON format

### DIFF
--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -194,7 +194,12 @@ abstract class Layer {
             parser.getString('color', defaults: ObjectGroup.defaultColorHex);
         final color =
             parser.getColor('color', defaults: ObjectGroup.defaultColor);
-        final objects = parser.getChildrenAs('object', TiledObject.parse);
+
+        final objects = parser.formatSpecificParsing(
+          (json) => json.getChildrenAs('objects', TiledObject.parse),
+          (xml) => xml.getChildrenAs('object', TiledObject.parse),
+        );
+
         layer = ObjectGroup(
           id: id,
           name: name,

--- a/packages/tiled/lib/src/objects/tiled_object.dart
+++ b/packages/tiled/lib/src/objects/tiled_object.dart
@@ -118,11 +118,11 @@ class TiledObject {
     );
 
     final ellipse = parser.formatSpecificParsing(
-      (json) => json.getBool('ellipse'),
+      (json) => json.getBool('ellipse', defaults: false),
       (xml) => xml.getChildren('ellipse').isNotEmpty,
     );
     final point = parser.formatSpecificParsing(
-      (json) => json.getBool('point'),
+      (json) => json.getBool('point', defaults: false),
       (xml) => xml.getChildren('point').isNotEmpty,
     );
     final text = parser.getSingleChildOrNullAs('text', Text.parse);


### PR DESCRIPTION
# Description

When loading and parsing JSON Format, `objectGroup` layers wheren't parsed correctly, which resulted in empty entry.

The main problem was that in JSON Format it is called "objects" instead of "object" like in XML. Here is a snippet of a JSON file exported with Tiled 1.8.2:

```json
         "draworder":"topdown",
         "id":8,
         "name":"obj",
         "objects":[
                {
                 "height":8,
                 "id":1,
                 "name":"start",
                 "rotation":0,
                 "type":"",
                 "visible":true,
                 "width":8,
                 "x":64,
                 "y":160
                }, 
                {
                 "height":8,
                 "id":2,
                 "name":"gem",
                 "rotation":0,
                 "type":"",
                 "visible":true,
                 "width":8,
                 "x":96,
                 "y":40
                }, 
```

## Breaking Change

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

