### PR TITLE
feat: Add tile access APIs to `TileLayer`

### DIFF
--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -509,6 +509,13 @@ class TileLayer extends Layer {
   /// Writes [gid] at Tiled tile `(x, y)` if that cell already exists.
   ///
   /// Does not allocate new chunks. Returns `true` when the stored GID changed.
+  ///
+  /// NOTE: Only the [Gid] matrix is updated: [tileData] on finite layers, or
+  /// [Chunk.tileData] on infinite layers. The parsed int lists ([data] and
+  /// [Chunk.data]) are left unchanged, so they can disagree with the matrix
+  /// after a write. Runtime reads go through [tileData] / [Chunk.tileData].
+  /// `flame_tiled`'s `RenderableTiledMap.setTileData` already has this split:
+  /// it assigns into `layer.tileData` and never rewrites `layer.data`.
   bool setTileAt(int x, int y, Gid gid) {
     final data = tileData;
     if (data != null) {

--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
@@ -362,6 +363,12 @@ abstract class Layer {
   }
 }
 
+/// Called for each cell of a [TileLayer] in Tiled world tile coordinates.
+///
+/// The [x] and [y] parameters are the Tiled world tile coordinates.
+/// The [gid] parameter is the GID of the tile at the given coordinates.
+typedef TileVisitor = void Function(int x, int y, Gid gid);
+
 class TileLayer extends Layer {
   /// Column count. Same as map width for fixed-size maps.
   int width;
@@ -427,6 +434,144 @@ class TileLayer extends Layer {
       return null;
     }
     return Gid.generate(data, width, height);
+  }
+
+  /// Inclusive-exclusive tile bounds of this layer in Tiled world coordinates.
+  ///
+  /// Finite layers use `[0, width) × [0, height)`. Infinite layers use the
+  /// axis-aligned bounds of all chunks (`left`/`top` are the minimum tile
+  /// indices, which may be negative). Returns `null` when there is no tile
+  /// matrix and no chunks.
+  Rectangle<int>? get contentBounds {
+    if (tileData != null) {
+      return Rectangle(0, 0, width, height);
+    }
+
+    final layerChunks = chunks;
+    if (layerChunks == null || layerChunks.isEmpty) {
+      return null;
+    }
+
+    var minX = layerChunks.first.x;
+    var minY = layerChunks.first.y;
+    var maxX = minX + layerChunks.first.width;
+    var maxY = minY + layerChunks.first.height;
+
+    for (var i = 1; i < layerChunks.length; i++) {
+      final chunk = layerChunks[i];
+      if (chunk.x < minX) {
+        minX = chunk.x;
+      }
+      if (chunk.y < minY) {
+        minY = chunk.y;
+      }
+      final chunkMaxX = chunk.x + chunk.width;
+      final chunkMaxY = chunk.y + chunk.height;
+      if (chunkMaxX > maxX) {
+        maxX = chunkMaxX;
+      }
+      if (chunkMaxY > maxY) {
+        maxY = chunkMaxY;
+      }
+    }
+
+    return Rectangle(minX, minY, maxX - minX, maxY - minY);
+  }
+
+  /// Walks every cell in Tiled world tile coordinates
+  /// and calls the [action] function with the x, y, and gid of the tile.
+  void forEachTile(TileVisitor action) {
+    final data = tileData;
+    if (data != null) {
+      for (var ty = 0; ty < data.length; ty++) {
+        final row = data[ty];
+        for (var tx = 0; tx < row.length; tx++) {
+          action(tx, ty, row[tx]);
+        }
+      }
+      return;
+    }
+
+    final layerChunks = chunks;
+    if (layerChunks == null) {
+      return;
+    }
+
+    for (final chunk in layerChunks) {
+      for (var localY = 0; localY < chunk.tileData.length; localY++) {
+        final row = chunk.tileData[localY];
+        for (var localX = 0; localX < row.length; localX++) {
+          action(chunk.x + localX, chunk.y + localY, row[localX]);
+        }
+      }
+    }
+  }
+
+  /// Returns the GID at Tiled tile `(x, y)` if it exists, otherwise returns
+  /// null.
+  Gid? tileAt(int x, int y) {
+    final data = tileData;
+    if (data != null) {
+      if (y < 0 || x < 0 || y >= data.length || x >= data[y].length) {
+        return null;
+      }
+      return data[y][x];
+    }
+
+    final chunk = _chunkAt(x, y);
+    if (chunk == null) {
+      return null;
+    }
+    return chunk.tileData[y - chunk.y][x - chunk.x];
+  }
+
+  /// Writes [gid] at Tiled tile `(x, y)` if that cell already exists.
+  ///
+  /// Does not allocate new chunks. Returns `true` when the stored GID changed.
+  bool setTileAt(int x, int y, Gid gid) {
+    final current = tileAt(x, y);
+    if (current == null || !_gidChanged(current, gid)) {
+      return false;
+    }
+
+    final data = tileData;
+    if (data != null) {
+      data[y][x] = gid;
+      return true;
+    }
+
+    final chunk = _chunkAt(x, y);
+    if (chunk == null) {
+      return false;
+    }
+    chunk.tileData[y - chunk.y][x - chunk.x] = gid;
+    return true;
+  }
+
+  /// Returns the chunk at Tiled tile `(x, y)` if it exists, otherwise returns
+  /// null.
+  Chunk? _chunkAt(int x, int y) {
+    final layerChunks = chunks;
+    if (layerChunks == null) {
+      return null;
+    }
+    for (final chunk in layerChunks) {
+      if (x >= chunk.x &&
+          x < chunk.x + chunk.width &&
+          y >= chunk.y &&
+          y < chunk.y + chunk.height) {
+        return chunk;
+      }
+    }
+    return null;
+  }
+
+  /// Returns true if the GID has changed, otherwise returns false.
+  static bool _gidChanged(Gid current, Gid gid) {
+    return current.tile != gid.tile ||
+        current.flips.horizontally != gid.flips.horizontally ||
+        current.flips.vertically != gid.flips.vertically ||
+        current.flips.diagonally != gid.flips.diagonally;
   }
 }
 

--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -611,7 +611,8 @@ class TileLayer extends Layer {
     return current.tile == gid.tile &&
         current.flips.horizontally == gid.flips.horizontally &&
         current.flips.vertically == gid.flips.vertically &&
-        current.flips.diagonally == gid.flips.diagonally;
+        current.flips.diagonally == gid.flips.diagonally &&
+        current.flips.antiDiagonally == gid.flips.antiDiagonally;
   }
 }
 

--- a/packages/tiled/lib/src/layer.dart
+++ b/packages/tiled/lib/src/layer.dart
@@ -443,39 +443,16 @@ class TileLayer extends Layer {
   /// indices, which may be negative). Returns `null` when there is no tile
   /// matrix and no chunks.
   Rectangle<int>? get contentBounds {
-    if (tileData != null) {
-      return Rectangle(0, 0, width, height);
+    final data = tileData;
+    if (data != null) {
+      return _finiteContentBounds(data);
     }
 
     final layerChunks = chunks;
-    if (layerChunks == null || layerChunks.isEmpty) {
-      return null;
+    if (layerChunks != null && layerChunks.isNotEmpty) {
+      return _infiniteContentBounds(layerChunks);
     }
-
-    var minX = layerChunks.first.x;
-    var minY = layerChunks.first.y;
-    var maxX = minX + layerChunks.first.width;
-    var maxY = minY + layerChunks.first.height;
-
-    for (var i = 1; i < layerChunks.length; i++) {
-      final chunk = layerChunks[i];
-      if (chunk.x < minX) {
-        minX = chunk.x;
-      }
-      if (chunk.y < minY) {
-        minY = chunk.y;
-      }
-      final chunkMaxX = chunk.x + chunk.width;
-      final chunkMaxY = chunk.y + chunk.height;
-      if (chunkMaxX > maxX) {
-        maxX = chunkMaxX;
-      }
-      if (chunkMaxY > maxY) {
-        maxY = chunkMaxY;
-      }
-    }
-
-    return Rectangle(minX, minY, maxX - minX, maxY - minY);
+    return null;
   }
 
   /// Walks every cell in Tiled world tile coordinates
@@ -518,43 +495,107 @@ class TileLayer extends Layer {
       return data[y][x];
     }
 
-    final chunk = _chunkAt(x, y);
-    if (chunk == null) {
-      return null;
+    final layerChunks = chunks;
+    if (layerChunks != null && layerChunks.isNotEmpty) {
+      final chunk = _chunkAt(layerChunks, x, y);
+      if (chunk == null) {
+        return null;
+      }
+      return chunk.tileData[y - chunk.y][x - chunk.x];
     }
-    return chunk.tileData[y - chunk.y][x - chunk.x];
+    return null;
   }
 
   /// Writes [gid] at Tiled tile `(x, y)` if that cell already exists.
   ///
   /// Does not allocate new chunks. Returns `true` when the stored GID changed.
   bool setTileAt(int x, int y, Gid gid) {
-    final current = tileAt(x, y);
-    if (current == null || !_gidChanged(current, gid)) {
-      return false;
-    }
-
     final data = tileData;
     if (data != null) {
-      data[y][x] = gid;
-      return true;
+      return _setFiniteTileAt(data, x, y, gid);
     }
 
-    final chunk = _chunkAt(x, y);
-    if (chunk == null) {
+    final layerChunks = chunks;
+    if (layerChunks != null && layerChunks.isNotEmpty) {
+      return _setInfiniteTileAt(layerChunks, x, y, gid);
+    }
+    return false;
+  }
+
+  static bool _setFiniteTileAt(
+    List<List<Gid>> data,
+    int x,
+    int y,
+    Gid gid,
+  ) {
+    // World (x, y) indexes the dense matrix directly.
+    if (y < 0 || x < 0 || y >= data.length || x >= data[y].length) {
       return false;
     }
-    chunk.tileData[y - chunk.y][x - chunk.x] = gid;
+    if (_gidsEqual(data[y][x], gid)) {
+      return false;
+    }
+    data[y][x] = gid;
     return true;
+  }
+
+  static bool _setInfiniteTileAt(
+    List<Chunk> layerChunks,
+    int x,
+    int y,
+    Gid gid,
+  ) {
+    // World (x, y) maps into whichever chunk covers that cell.
+    final chunk = _chunkAt(layerChunks, x, y);
+    if (chunk == null) {
+      // No existing chunk contains this cell; we do not grow the map.
+      return false;
+    }
+    final localX = x - chunk.x;
+    final localY = y - chunk.y;
+    if (_gidsEqual(chunk.tileData[localY][localX], gid)) {
+      return false;
+    }
+    chunk.tileData[localY][localX] = gid;
+    return true;
+  }
+
+  static Rectangle<int> _finiteContentBounds(List<List<Gid>> data) {
+    final height = data.length;
+    final width = height == 0 ? 0 : data.first.length;
+    return Rectangle(0, 0, width, height);
+  }
+
+  static Rectangle<int> _infiniteContentBounds(List<Chunk> layerChunks) {
+    var minX = layerChunks.first.x;
+    var minY = layerChunks.first.y;
+    var maxX = minX + layerChunks.first.width;
+    var maxY = minY + layerChunks.first.height;
+
+    for (var i = 1; i < layerChunks.length; i++) {
+      final chunk = layerChunks[i];
+      if (chunk.x < minX) {
+        minX = chunk.x;
+      }
+      if (chunk.y < minY) {
+        minY = chunk.y;
+      }
+      final chunkMaxX = chunk.x + chunk.width;
+      final chunkMaxY = chunk.y + chunk.height;
+      if (chunkMaxX > maxX) {
+        maxX = chunkMaxX;
+      }
+      if (chunkMaxY > maxY) {
+        maxY = chunkMaxY;
+      }
+    }
+
+    return Rectangle(minX, minY, maxX - minX, maxY - minY);
   }
 
   /// Returns the chunk at Tiled tile `(x, y)` if it exists, otherwise returns
   /// null.
-  Chunk? _chunkAt(int x, int y) {
-    final layerChunks = chunks;
-    if (layerChunks == null) {
-      return null;
-    }
+  static Chunk? _chunkAt(List<Chunk> layerChunks, int x, int y) {
     for (final chunk in layerChunks) {
       if (x >= chunk.x &&
           x < chunk.x + chunk.width &&
@@ -566,12 +607,11 @@ class TileLayer extends Layer {
     return null;
   }
 
-  /// Returns true if the GID has changed, otherwise returns false.
-  static bool _gidChanged(Gid current, Gid gid) {
-    return current.tile != gid.tile ||
-        current.flips.horizontally != gid.flips.horizontally ||
-        current.flips.vertically != gid.flips.vertically ||
-        current.flips.diagonally != gid.flips.diagonally;
+  static bool _gidsEqual(Gid current, Gid gid) {
+    return current.tile == gid.tile &&
+        current.flips.horizontally == gid.flips.horizontally &&
+        current.flips.vertically == gid.flips.vertically &&
+        current.flips.diagonally == gid.flips.diagonally;
   }
 }
 

--- a/packages/tiled/test/tile_layer_access_test.dart
+++ b/packages/tiled/test/tile_layer_access_test.dart
@@ -43,7 +43,7 @@ void main() {
     });
 
     test('setTileAt treats flip changes as a change', () {
-      const flipped = Gid(
+      const flippedH = Gid(
         1,
         Flips(
           horizontally: true,
@@ -52,9 +52,21 @@ void main() {
           antiDiagonally: false,
         ),
       );
-      expect(layer.setTileAt(0, 0, flipped), isTrue);
+      expect(layer.setTileAt(0, 0, flippedH), isTrue);
       expect(layer.tileAt(0, 0)!.tile, 1);
       expect(layer.tileAt(0, 0)!.flips.horizontally, isTrue);
+
+      const flippedAnti = Gid(
+        1,
+        Flips(
+          horizontally: true,
+          vertically: false,
+          diagonally: false,
+          antiDiagonally: true,
+        ),
+      );
+      expect(layer.setTileAt(0, 0, flippedAnti), isTrue);
+      expect(layer.tileAt(0, 0)!.flips.antiDiagonally, isTrue);
     });
 
     test('forEachTile visits every cell', () {

--- a/packages/tiled/test/tile_layer_access_test.dart
+++ b/packages/tiled/test/tile_layer_access_test.dart
@@ -42,6 +42,21 @@ void main() {
       expect(layer.setTileAt(5, 5, const Gid(1, Flips.defaults())), isFalse);
     });
 
+    test('setTileAt treats flip changes as a change', () {
+      const flipped = Gid(
+        1,
+        Flips(
+          horizontally: true,
+          vertically: false,
+          diagonally: false,
+          antiDiagonally: false,
+        ),
+      );
+      expect(layer.setTileAt(0, 0, flipped), isTrue);
+      expect(layer.tileAt(0, 0)!.tile, 1);
+      expect(layer.tileAt(0, 0)!.flips.horizontally, isTrue);
+    });
+
     test('forEachTile visits every cell', () {
       final visited = <(int, int, int)>[];
       layer.forEachTile((x, y, gid) {

--- a/packages/tiled/test/tile_layer_access_test.dart
+++ b/packages/tiled/test/tile_layer_access_test.dart
@@ -1,0 +1,125 @@
+import 'dart:math';
+
+import 'package:test/test.dart';
+import 'package:tiled/tiled.dart';
+
+void main() {
+  group('TileLayer finite', () {
+    late TileLayer layer;
+
+    setUp(() {
+      layer = TileLayer(
+        name: 'finite',
+        width: 2,
+        height: 2,
+        data: [1, 2, 3, 4],
+      );
+    });
+
+    test('contentBounds matches width and height', () {
+      expect(layer.contentBounds, const Rectangle(0, 0, 2, 2));
+    });
+
+    test('tileAt reads world coordinates', () {
+      expect(layer.tileAt(0, 0)!.tile, 1);
+      expect(layer.tileAt(1, 0)!.tile, 2);
+      expect(layer.tileAt(0, 1)!.tile, 3);
+      expect(layer.tileAt(1, 1)!.tile, 4);
+      expect(layer.tileAt(-1, 0), isNull);
+      expect(layer.tileAt(2, 0), isNull);
+    });
+
+    test('setTileAt updates an existing cell', () {
+      expect(
+        layer.setTileAt(1, 0, const Gid(9, Flips.defaults())),
+        isTrue,
+      );
+      expect(layer.tileAt(1, 0)!.tile, 9);
+      expect(
+        layer.setTileAt(1, 0, const Gid(9, Flips.defaults())),
+        isFalse,
+      );
+      expect(layer.setTileAt(5, 5, const Gid(1, Flips.defaults())), isFalse);
+    });
+
+    test('forEachTile visits every cell', () {
+      final visited = <(int, int, int)>[];
+      layer.forEachTile((x, y, gid) {
+        visited.add((x, y, gid.tile));
+      });
+      expect(visited, [(0, 0, 1), (1, 0, 2), (0, 1, 3), (1, 1, 4)]);
+    });
+  });
+
+  group('TileLayer infinite chunks', () {
+    late TileLayer layer;
+
+    setUp(() {
+      final data = List<int>.filled(16 * 16, 0);
+      data[0] = 7;
+      data[1] = 8;
+      layer = TileLayer(
+        name: 'infinite',
+        width: 16,
+        height: 16,
+        chunks: [
+          Chunk(data: data, x: -16, y: -8, width: 16, height: 16),
+          Chunk(
+            data: List<int>.filled(16 * 16, 0)..[0] = 3,
+            x: 0,
+            y: -8,
+            width: 16,
+            height: 16,
+          ),
+        ],
+      );
+    });
+
+    test('contentBounds unions all chunks', () {
+      expect(layer.contentBounds, const Rectangle(-16, -8, 32, 16));
+    });
+
+    test('tileAt uses chunk world coordinates', () {
+      expect(layer.tileAt(-16, -8)!.tile, 7);
+      expect(layer.tileAt(-15, -8)!.tile, 8);
+      expect(layer.tileAt(0, -8)!.tile, 3);
+      expect(layer.tileAt(0, 0)!.tile, 0);
+      expect(layer.tileAt(-17, -8), isNull);
+    });
+
+    test('setTileAt updates a chunk cell', () {
+      expect(
+        layer.setTileAt(-16, -8, const Gid(11, Flips.defaults())),
+        isTrue,
+      );
+      expect(layer.tileAt(-16, -8)!.tile, 11);
+      expect(
+        layer.setTileAt(32, 32, const Gid(1, Flips.defaults())),
+        isFalse,
+      );
+    });
+
+    test('forEachTile uses world coordinates', () {
+      var found = 0;
+      layer.forEachTile((x, y, gid) {
+        if (gid.tile == 7) {
+          expect((x, y), (-16, -8));
+          found++;
+        }
+      });
+      expect(found, 1);
+    });
+  });
+
+  test('empty infinite layer has no contentBounds', () {
+    final layer = TileLayer(
+      name: 'empty',
+      width: 16,
+      height: 16,
+      chunks: [],
+    );
+    expect(layer.tileData, isNull);
+    expect(layer.contentBounds, isNull);
+    expect(layer.tileAt(0, 0), isNull);
+  });
+}


### PR DESCRIPTION
# Description

Adds a small tile-access API on `TileLayer` so callers can read, write, and iterate tiles without caring whether the layer is finite (`tileData`) or infinite (`chunks`).

Infinite maps from Tiled store GIDs on chunks at world tile coordinates (including negatives) and leave `tileData` null. Consumers such as `flame_tiled` currently have to special-case that. This PR keeps parsing unchanged and adds:

- `tileAt(x, y)` — GID at Tiled world coordinates, or `null` if the cell does not exist
- `setTileAt(x, y, gid)` — updates an existing cell (does not allocate new chunks); returns whether the stored GID changed
- `forEachTile(TileVisitor)` — visits every cell in world coordinates
- `contentBounds` — `Rectangle<int>?` of occupied tile space (`left`/`top` may be negative for infinite maps); `null` when there is no data and no chunks
- `TileVisitor` typedef for the `forEachTile` callback

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require users of the Tiled Dart library to manually update their apps to
accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Supports infinite-map loading in flame_tiled:

- https://github.com/flame-engine/flame/issues/2855
- https://github.com/flame-engine/flame/issues/3932

<!-- Links -->
[issue database]: https://github.com/flame-engine/tiled.dart/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org