### PR TITLE
ci: Add release workflows

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -12,8 +12,8 @@ jobs:
   dartdoc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
+      - uses: actions/checkout@v7
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
       - uses: flame-engine/flame-dartdoc-action@v2
@@ -21,7 +21,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v3
       - name: Run analysis
@@ -30,7 +30,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
         with:
           cache: true
@@ -43,7 +43,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
         with:
           cache: true

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,28 @@
+name: Prepare release
+on:
+  workflow_dispatch:
+    inputs:
+      prerelease:
+        description: 'Version as prerelease'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  prepare-release:
+    name: Prepare release
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: subosito/flutter-action@v2
+      - uses: bluefireteam/melos-action@v3
+        with:
+          run-versioning: ${{ inputs.prerelease == false }}
+          run-versioning-prerelease: ${{ inputs.prerelease == true }}
+          publish-dry-run: true
+          create-pr: true

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,9 +1,5 @@
 name: Publish packages
 on:
-  # Enable to also publish, when pushing a tag
-  #push:
-  #  tags:
-  #    - '*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write # Required for authentication using OIDC
     runs-on: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,25 @@
+name: Publish packages
+on:
+  # Enable to also publish, when pushing a tag
+  #push:
+  #  tags:
+  #    - '*'
+  workflow_dispatch:
+
+jobs:
+  publish-packages:
+    name: Publish packages
+    permissions:
+      contents: write
+      id-token: write # Required for authentication using OIDC
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: subosito/flutter-action@v2
+      - uses: bluefireteam/melos-action@v3
+        with:
+          publish: true
+          create-release: true
+

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     if: contains(github.event.head_commit.message, 'chore(release)')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,29 @@
+name: Tag release
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish-packages:
+    name: Create tags for release
+    permissions:
+      actions: write
+      contents: write
+    runs-on: [ ubuntu-latest ]
+    if: contains(github.event.head_commit.message, 'chore(release)')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: subosito/flutter-action@v2
+      - uses: bluefireteam/melos-action@v3
+        with:
+          tag: true
+      - name: Trigger publish for unpublished packages
+        run: |
+          melos exec -c1 --no-published --no-private --order-dependents -- \
+          gh workflow run release-publish.yml \
+          --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/title-validation.yml
+++ b/.github/workflows/title-validation.yml
@@ -9,6 +9,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,19 +166,24 @@ There are a few things to think about when doing a release:
  - Search through the codebase for `@Deprecated` methods/fields and remove the ones that are marked
    for removal in the version that you are intending to release.
  - Create a PR containing the changes for removing the deprecated entities.
- - Run `melos version -V <package1>:<version> -V <package2>:<version>` for Melos to generate
-   `CHANGELOG.md` files.
- - Go through the PRs with breaking changes and add migration documentation to the changelog.
-   There should be migration docs on each PR, if they haven't been copied to the commit message.
- - Run `melos publish` to make sure that there aren't any problems with any of the packages and make
-   sure that all the versions are correct.
- - Once you are satisfied with the result of the dry run, run `melos publish --no-dry-run`
- - Create a PR containing the updated changelog and `pubspec.yaml` files.
+ - Run the [Prepare release] workflow on GitHub. It runs `melos version`, does a dry run of
+   `melos publish` and opens a PR with the updated `CHANGELOG.md` and `pubspec.yaml` files.
+ - Go through the PRs with breaking changes and add migration documentation to the changelog in the
+   release PR. There should be migration docs on each PR, if they haven't been copied to the commit
+   message.
+ - Once the release PR is merged, the [Tag release] workflow creates the git tags and triggers the
+   [Publish packages] workflow for each unpublished package, which publishes it to pub.dev and
+   creates a GitHub release.
+
+The same steps can be done manually with `melos version` and `melos publish` if needed.
 
 
 [GitHub issue]: https://github.com/flame-engine/tiled.dart/issues/new
 [GitHub issues]: https://github.com/flame-engine/tiled.dart/issues/new
 [PRs]: https://github.com/flame-engine/tiled.dart/pulls
+[Prepare release]: https://github.com/flame-engine/tiled.dart/actions/workflows/release-prepare.yml
+[Tag release]: https://github.com/flame-engine/tiled.dart/actions/workflows/release-tag.yml
+[Publish packages]: https://github.com/flame-engine/tiled.dart/actions/workflows/release-publish.yml
 [fork guide]: https://guides.github.com/activities/forking/#fork
 [Discord]: https://discord.gg/pxrBmy4
 [Melos]: https://github.com/invertase/melos

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,15 @@ dev_dependencies:
 melos:
   repository: https://github.com/flame-engine/tiled.dart
 
+  command:
+    version:
+      # Only allow versioning to happen on main branch.
+      branch: main
+      # Generates a link to a prefilled GitHub release creation page.
+      releaseUrl: true
+      includeCommitId: true
+      linkToCommits: true
+
   scripts:
     coverage:
       run: |


### PR DESCRIPTION
# Description

Sets up the same release automation as in [flame](https://github.com/flame-engine/flame/tree/main/.github/workflows):

- `release-prepare.yml`: manually triggered (with an optional prerelease flag), runs `melos version` and a `melos publish` dry run, then opens a `chore(release): Publish packages` PR.
- `release-tag.yml`: runs when a release commit lands on `main`, creates the package tags and triggers the publish workflow for each unpublished package.
- `release-publish.yml`: publishes the package to pub.dev using OIDC and creates a GitHub release with the notes from the changelog.

Also adds the melos `version` config from flame (`branch: main`, `releaseUrl`, `includeCommitId`, `linkToCommits`) and updates the release section in `CONTRIBUTING.md`.

Additionally bumps all GitHub actions to their latest major versions: `actions/checkout` to v7 (was v2/v3/v4), `subosito/flutter-action` to v2 (was v1 in the dartdoc job) and `amannn/action-semantic-pull-request` to v6 (was v4).

## Notes

- Publishing via OIDC requires automated publishing from GitHub Actions to be enabled for the `tiled` package on pub.dev, with `flame-engine/tiled.dart` and the tag pattern `tiled-v{{version}}` configured.
- For the release PR created by `release-prepare.yml` to get CI runs, a PAT or GitHub App token can be passed to the `token` input of `melos-action`, same as in flame the default `GITHUB_TOKEN` is used here.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

[Contributor Guide]: https://github.com/flame-engine/tiled.dart/blob/main/CONTRIBUTING.md

https://claude.ai/code/session_016h5CfXvZUtr33Nmc4XN8BC
