### PR TITLE
feat: Inherit template values, translate template gids and copy external tileset version

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ class DirectoryProvider extends ParserProvider {
 `Parser.fromString` creates an `XmlParser` or a `JsonParser` depending on the contents. Every file
 is requested at most once per parsed map.
 
+Objects that use a template inherit every value they do not specify themselves from the object of
+the template, and their `gid` is translated to the tilesets of the map. When the map does not
+contain the tileset of the template it is added to `TiledMap.tilesets`, like Tiled does when loading
+the map.
+
 The providers are passed to `parseTmx` or `parseJson`:
 
 ```dart

--- a/packages/tiled/lib/src/common/gid.dart
+++ b/packages/tiled/lib/src/common/gid.dart
@@ -38,6 +38,13 @@ class Gid {
   static const int flippedDiagonallyFlag = 0x20000000;
   static const int flippedAntiDiagonallyFlag = 0x10000000;
 
+  /// The bits of a gid that hold the flips instead of the tile.
+  static const int flagMask =
+      flippedHorizontallyFlag |
+      flippedVerticallyFlag |
+      flippedDiagonallyFlag |
+      flippedAntiDiagonallyFlag;
+
   final int tile;
   final Flips flips;
 
@@ -54,12 +61,7 @@ class Gid {
     final flippedAntiDiagonally =
         gid & flippedAntiDiagonallyFlag == flippedAntiDiagonallyFlag;
     // clear id from flips
-    final tileId =
-        gid &
-        ~(flippedHorizontallyFlag |
-            flippedVerticallyFlag |
-            flippedDiagonallyFlag |
-            flippedAntiDiagonallyFlag);
+    final tileId = gid & ~flagMask;
     final flip = Flips(
       horizontally: flippedHorizontally,
       vertically: flippedVertically,

--- a/packages/tiled/lib/src/objects/tiled_object.dart
+++ b/packages/tiled/lib/src/objects/tiled_object.dart
@@ -59,8 +59,8 @@ class TiledObject {
   bool point;
   bool rectangle;
 
-  /// The path of the template file this object references, if any, exactly
-  /// as it is written in the map file.
+  /// The path of the template file this object references, if any, relative
+  /// to the map.
   String? templatePath;
 
   /// The parsed template of this object, if [templatePath] is set and one of
@@ -108,44 +108,74 @@ class TiledObject {
 
   /// Parses an object.
   ///
+  /// An object that references a template through its `template` attribute
+  /// inherits every value it does not specify itself from the object of that
+  /// template, and its properties are merged with the ones of the template.
+  /// The tile of the template is referenced relative to the tileset of the
+  /// template file, so [gid] stays null when it is inherited until
+  /// [TiledMap.parse] translates it to the tilesets of the map.
+  ///
   /// Set [inTemplate] when parsing the object of a template file, which has no
   /// id.
   factory TiledObject.parse(Parser parser, {bool inTemplate = false}) {
-    final x = parser.getDouble('x', defaults: 0);
-    final y = parser.getDouble('y', defaults: 0);
-    final height = parser.getDouble('height', defaults: 0);
-    final width = parser.getDouble('width', defaults: 0);
-    final rotation = parser.getDouble('rotation', defaults: 0);
-    final visible = parser.getBool('visible', defaults: true);
+    final templatePath = parser.getStringOrNull('template');
+    final template = parser.getExternalOrNullAs(templatePath, Template.parse);
+    final templateObject = template?.object;
+
     final id = inTemplate
         ? parser.getInt('id', defaults: 0)
         : parser.getInt('id');
+    final x = parser.getDouble('x', defaults: 0);
+    final y = parser.getDouble('y', defaults: 0);
+    final height =
+        parser.getDoubleOrNull('height') ?? templateObject?.height ?? 0;
+    final width = parser.getDoubleOrNull('width') ?? templateObject?.width ?? 0;
+    final rotation =
+        parser.getDoubleOrNull('rotation') ?? templateObject?.rotation ?? 0;
+    final visible =
+        parser.getBoolOrNull('visible') ?? templateObject?.visible ?? true;
     final gid = parser.getIntOrNull('gid');
-    final name = parser.getString('name', defaults: '');
+    final name = parser.getStringOrNull('name') ?? templateObject?.name ?? '';
 
     // Tiled 1.9 and above versions running in compatibility mode set to
     // "Tiled 1.8" will still write out "Class" property as "type". So try both
     // before using default value.
-    final type = parser.getString(
-      'class',
-      defaults: parser.getString('type', defaults: ''),
-    );
+    final type =
+        parser.getStringOrNull('class') ??
+        parser.getStringOrNull('type') ??
+        templateObject?.type ??
+        '';
 
-    final ellipse = parser.formatSpecificParsing(
-      (json) => json.getBool('ellipse', defaults: false),
-      (xml) => xml.getChildren('ellipse').isNotEmpty,
-    );
-    final point = parser.formatSpecificParsing(
-      (json) => json.getBool('point', defaults: false),
-      (xml) => xml.getChildren('point').isNotEmpty,
-    );
-    final text = parser.getSingleChildOrNullAs('text', Text.parse);
-    final templatePath = parser.getStringOrNull('template');
-    final template = parser.getExternalOrNullAs(templatePath, Template.parse);
-    final properties = parser.getProperties();
+    final ellipse =
+        parser.formatSpecificParsing(
+          (json) => json.getBoolOrNull('ellipse'),
+          (xml) => xml.getChildren('ellipse').isNotEmpty ? true : null,
+        ) ??
+        templateObject?.ellipse ??
+        false;
+    final point =
+        parser.formatSpecificParsing(
+          (json) => json.getBoolOrNull('point'),
+          (xml) => xml.getChildren('point').isNotEmpty ? true : null,
+        ) ??
+        templateObject?.point ??
+        false;
+    final text =
+        parser.getSingleChildOrNullAs('text', Text.parse) ??
+        templateObject?.text;
+    final properties = CustomProperties({
+      ...?templateObject?.properties.byName,
+      ...parser.getProperties().byName,
+    });
 
-    final polygon = parsePointList(parser, 'polygon');
-    final polyline = parsePointList(parser, 'polyline');
+    final ownPolygon = parsePointList(parser, 'polygon');
+    final ownPolyline = parsePointList(parser, 'polyline');
+    final polygon = ownPolygon.isNotEmpty
+        ? ownPolygon
+        : templateObject?.polygon ?? [];
+    final polyline = ownPolyline.isNotEmpty
+        ? ownPolyline
+        : templateObject?.polyline ?? [];
 
     final rectangle = polyline.isEmpty && polygon.isEmpty && !ellipse && !point;
 
@@ -162,7 +192,9 @@ class TiledObject {
       ellipse: ellipse,
       point: point,
       rectangle: rectangle,
-      templatePath: templatePath,
+      templatePath: templatePath == null
+          ? null
+          : parser.resolvePath(templatePath),
       template: template,
       text: text,
       visible: visible,

--- a/packages/tiled/lib/src/parser.dart
+++ b/packages/tiled/lib/src/parser.dart
@@ -184,8 +184,12 @@ abstract class Parser {
     if (path == null) {
       return null;
     }
-    return _externalFiles.parse(_resolvePath(_directory, path), parse);
+    return _externalFiles.parse(resolvePath(path), parse);
   }
+
+  /// Resolves [path], written relative to the file this parser was created
+  /// from, to a path relative to the map.
+  String resolvePath(String path) => _resolvePath(_directory, path);
 
   List<T> getChildrenAs<T>(String name, T Function(Parser) mapper) {
     return getChildren(name).map(mapper).toList();

--- a/packages/tiled/lib/src/tiled_map.dart
+++ b/packages/tiled/lib/src/tiled_map.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:tiled/tiled.dart';
@@ -345,6 +346,77 @@ class TiledMap {
     }
   }
 
+  /// Translates the tile of every object that inherits it from a template,
+  /// which is referenced relative to the tileset of the template file, to the
+  /// tilesets of the map. Adds the tileset of the template to [tilesets] when
+  /// the map does not contain it yet, like Tiled does.
+  static void _resolveTemplateGids(List<Tileset> tilesets, List<Layer> layers) {
+    for (final layer in layers) {
+      if (layer is Group) {
+        _resolveTemplateGids(tilesets, layer.layers);
+      } else if (layer is ObjectGroup) {
+        for (final object in layer.objects) {
+          _resolveTemplateGid(tilesets, object);
+        }
+      }
+    }
+  }
+
+  static void _resolveTemplateGid(List<Tileset> tilesets, TiledObject object) {
+    final template = object.template;
+    final templateGid = template?.object?.gid;
+    final templateTileset = template?.tileSet;
+    if (object.gid != null || templateGid == null || templateTileset == null) {
+      return;
+    }
+    final localId =
+        Gid.fromInt(templateGid).tile - (templateTileset.firstGid ?? 1);
+    final flags = templateGid & Gid.flagMask;
+    final tileset =
+        tilesets.firstWhereOrNull(
+          (tileset) =>
+              tileset.source != null &&
+              tileset.source == templateTileset.source,
+        ) ??
+        _addTileset(tilesets, templateTileset);
+    object.gid = flags | ((tileset.firstGid ?? 0) + localId);
+  }
+
+  static Tileset _addTileset(List<Tileset> tilesets, Tileset template) {
+    final nextGids = tilesets.map<int>((tileset) {
+      final nextLocalId =
+          (tileset.tiles.map((tile) => tile.localId).maxOrNull ?? -1) + 1;
+      return (tileset.firstGid ?? 0) + max(nextLocalId, tileset.tileCount ?? 0);
+    });
+    final firstGid = max(1, nextGids.maxOrNull ?? 1);
+    final tileset = Tileset(
+      firstGid: firstGid,
+      source: template.source,
+      name: template.name,
+      tileWidth: template.tileWidth,
+      tileHeight: template.tileHeight,
+      spacing: template.spacing,
+      margin: template.margin,
+      tileCount: template.tileCount,
+      columns: template.columns,
+      objectAlignment: template.objectAlignment,
+      tiles: template.tiles,
+      image: template.image,
+      tileOffset: template.tileOffset,
+      grid: template.grid,
+      properties: template.properties,
+      terrains: template.terrains,
+      wangSets: template.wangSets,
+      version: template.version,
+      tiledVersion: template.tiledVersion,
+      backgroundColor: template.backgroundColor,
+      transparentColor: template.transparentColor,
+      type: template.type,
+    );
+    tilesets.add(tileset);
+    return tileset;
+  }
+
   factory TiledMap.parse(Parser parser) {
     if (parser is XmlParser && parser.element.name.local != 'map') {
       throw 'XML is not in TMX format';
@@ -376,6 +448,7 @@ class TiledMap {
       (xml) => xml.getChildrenAs('tileset', Tileset.parse),
     );
     final layers = Layer.parseLayers(parser);
+    _resolveTemplateGids(tilesets, layers);
     final properties = parser.getProperties();
     final editorSettings = parser.getChildrenAs(
       'editorsettings',

--- a/packages/tiled/lib/src/tileset/tileset.dart
+++ b/packages/tiled/lib/src/tileset/tileset.dart
@@ -46,6 +46,9 @@ import 'package:tiled/tiled.dart';
 /// Can contain any number: `<tile>`
 class Tileset {
   int? firstGid;
+
+  /// The path of the external tileset file, relative to the map, also when
+  /// the tileset is referenced from a template file.
   String? source;
   String? name;
   int? tileWidth;
@@ -153,7 +156,7 @@ class Tileset {
 
     final result = Tileset(
       firstGid: firstGid,
-      source: source,
+      source: source == null ? null : parser.resolvePath(source),
       name: name,
       tileWidth: tileWidth,
       tileHeight: tileHeight,

--- a/packages/tiled/lib/src/tileset/tileset.dart
+++ b/packages/tiled/lib/src/tileset/tileset.dart
@@ -183,7 +183,8 @@ class Tileset {
   }
 
   void _mergeExternalTileset(Tileset tileset) {
-    // Copy attributes if not null
+    version = tileset.version;
+    type = tileset.type;
     backgroundColor = tileset.backgroundColor ?? backgroundColor;
     columns = tileset.columns ?? columns;
     firstGid = tileset.firstGid ?? firstGid;
@@ -199,7 +200,6 @@ class Tileset {
     tileHeight = tileset.tileHeight ?? tileHeight;
     tileWidth = tileset.tileWidth ?? tileWidth;
     transparentColor = tileset.transparentColor ?? transparentColor;
-    // Add List-Attributes
     properties.byName.addAll(tileset.properties.byName);
     terrains.addAll(tileset.terrains);
     tiles.addAll(tileset.tiles);

--- a/packages/tiled/test/fixtures/map_with_template.json
+++ b/packages/tiled/test/fixtures/map_with_template.json
@@ -39,6 +39,32 @@
                  "width":8,
                  "x":16,
                  "y":16
+                },
+                {
+                 "id":3,
+                 "name":"Overridden",
+                 "properties":[
+                        {
+                         "name":"health",
+                         "type":"int",
+                         "value":3
+                        },
+                        {
+                         "name":"speed",
+                         "type":"float",
+                         "value":1.5
+                        }],
+                 "template":"object_template.tj",
+                 "width":32,
+                 "x":0,
+                 "y":0
+                },
+                {
+                 "gid":2,
+                 "id":4,
+                 "template":"object_template.tj",
+                 "x":0,
+                 "y":0
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -47,7 +73,7 @@
          "y":0
         }],
  "nextlayerid":3,
- "nextobjectid":3,
+ "nextobjectid":5,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.8.90",

--- a/packages/tiled/test/fixtures/map_with_template.tmx
+++ b/packages/tiled/test/fixtures/map_with_template.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.8" tiledversion="1.8.90" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="3">
+<map version="1.8" tiledversion="1.8.90" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="5">
  <tileset firstgid="1" source="tileset.tsx"/>
  <tileset firstgid="137" source="tileset_with_template.tsx"/>
  <layer id="1" name="Tile Layer 1" width="5" height="5">
@@ -14,5 +14,12 @@
  <objectgroup id="2" name="Objects">
   <object id="1" template="object_template.tx" x="32" y="48"/>
   <object id="2" name="Plain" x="16" y="16" width="8" height="8"/>
+  <object id="3" template="object_template.tx" name="Overridden" x="0" y="0" width="32">
+   <properties>
+    <property name="health" type="int" value="3"/>
+    <property name="speed" type="float" value="1.5"/>
+   </properties>
+  </object>
+  <object id="4" template="object_template.tx" gid="2" x="0" y="0"/>
  </objectgroup>
 </map>

--- a/packages/tiled/test/fixtures/map_with_template_no_tileset.tmx
+++ b/packages/tiled/test/fixtures/map_with_template_no_tileset.tmx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.8" tiledversion="1.8.90" orientation="orthogonal" renderorder="right-down" width="1" height="1" tilewidth="16" tileheight="16" infinite="0" nextlayerid="3" nextobjectid="3">
+ <tileset firstgid="1" name="other" tilewidth="32" tileheight="32" tilecount="2" columns="0">
+  <grid orientation="orthogonal" width="1" height="1"/>
+  <tile id="0">
+   <image width="32" height="32" source="image1.png"/>
+  </tile>
+  <tile id="1">
+   <image width="32" height="32" source="image2.png"/>
+  </tile>
+ </tileset>
+ <layer id="1" name="Tile Layer 1" width="1" height="1">
+  <data encoding="csv">
+0
+</data>
+ </layer>
+ <objectgroup id="2" name="Objects">
+  <object id="1" template="object_template.tx" x="0" y="0"/>
+  <object id="2" template="object_template_flipped.tx" x="16" y="0"/>
+ </objectgroup>
+</map>

--- a/packages/tiled/test/fixtures/object_template_flipped.tx
+++ b/packages/tiled/test/fixtures/object_template_flipped.tx
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template>
+ <tileset firstgid="1" source="tileset.tsx"/>
+ <object name="Flipped" gid="2147483653" width="16" height="16"/>
+</template>

--- a/packages/tiled/test/provider_test.dart
+++ b/packages/tiled/test/provider_test.dart
@@ -69,6 +69,16 @@ void main() {
       expect(tileset.tiles, isEmpty);
     });
 
+    test('external tilesets provide their version and type', () {
+      final map = TiledMap.parseTmx(
+        readFixture('map_images.tmx'),
+        providers: [FixtureProvider()],
+      );
+      final tileset = map.tilesetByName('external');
+      expect(tileset.version, equals('1.2'));
+      expect(tileset.type, equals(TilesetType.tileset));
+    });
+
     test('external tilesets are resolved for json maps', () {
       final map = TiledMap.parseJson(
         readFixture('map_with_template.json'),

--- a/packages/tiled/test/provider_test.dart
+++ b/packages/tiled/test/provider_test.dart
@@ -155,7 +155,7 @@ void main() {
       final tileObjects =
           (tileset.tiles.first.objectGroup! as ObjectGroup).objects;
       final templateTileset = tileObjects.single.template!.tileSet!;
-      expect(templateTileset.source, equals('../nested_tileset.tsx'));
+      expect(templateTileset.source, equals('tilesets/nested_tileset.tsx'));
       expect(templateTileset.name, isNull);
     });
 

--- a/packages/tiled/test/template_test.dart
+++ b/packages/tiled/test/template_test.dart
@@ -1,0 +1,113 @@
+import 'package:test/test.dart';
+import 'package:tiled/tiled.dart';
+
+import 'fixture_provider.dart';
+
+void main() {
+  const readFixture = FixtureProvider.read;
+
+  List<TiledObject> objectsOf(TiledMap map) {
+    return (map.layerByName('Objects') as ObjectGroup).objects;
+  }
+
+  void expectInherited(TiledMap map) {
+    final objects = objectsOf(map);
+
+    final inherited = objects[0];
+    expect(inherited.name, equals('Templated'));
+    expect(inherited.type, equals('enemy'));
+    expect(inherited.gid, equals(5));
+    expect(inherited.width, equals(16));
+    expect(inherited.height, equals(16));
+    expect(inherited.x, equals(32));
+    expect(inherited.y, equals(48));
+    expect(inherited.isRectangle, isTrue);
+    expect(inherited.properties.getValue<int>('health'), equals(10));
+
+    final overridden = objects[2];
+    expect(overridden.name, equals('Overridden'));
+    expect(overridden.type, equals('enemy'));
+    expect(overridden.gid, equals(5));
+    expect(overridden.width, equals(32));
+    expect(overridden.height, equals(16));
+    expect(overridden.properties.getValue<int>('health'), equals(3));
+    expect(overridden.properties.getValue<double>('speed'), equals(1.5));
+
+    final ownGid = objects[3];
+    expect(ownGid.gid, equals(2));
+    expect(ownGid.name, equals('Templated'));
+  }
+
+  group('Template inheritance', () {
+    test('objects inherit unspecified values from their template in tmx', () {
+      final map = TiledMap.parseTmx(
+        readFixture('map_with_template.tmx'),
+        providers: [FixtureProvider()],
+      );
+      expectInherited(map);
+    });
+
+    test('objects inherit unspecified values from their template in json', () {
+      final map = TiledMap.parseJson(
+        readFixture('map_with_template.json'),
+        providers: [FixtureProvider()],
+      );
+      expectInherited(map);
+    });
+
+    test('objects without a resolved template keep their own values', () {
+      final map = TiledMap.parseTmx(readFixture('map_with_template.tmx'));
+      final objects = objectsOf(map);
+      expect(objects[0].name, equals(''));
+      expect(objects[0].gid, isNull);
+      expect(objects[2].name, equals('Overridden'));
+      expect(objects[2].properties.getValue<double>('speed'), equals(1.5));
+    });
+
+    test('inherited gids are translated to the tilesets of the map', () {
+      final map = TiledMap.parseTmx(
+        readFixture('map_with_template_no_tileset.tmx'),
+        providers: [FixtureProvider()],
+      );
+      expect(map.tilesets.map((tileset) => tileset.name), [
+        'other',
+        'external',
+      ]);
+      final added = map.tilesets[1];
+      expect(added.source, equals('tileset.tsx'));
+      expect(added.firstGid, equals(3));
+      expect(added.tileCount, equals(136));
+
+      final objects = objectsOf(map);
+      expect(objects[0].gid, equals(7));
+      expect(map.tileByGid(7)!.localId, equals(4));
+
+      final flipped = Gid.fromInt(objects[1].gid!);
+      expect(flipped.tile, equals(7));
+      expect(flipped.flips.horizontally, isTrue);
+      expect(flipped.flips.vertically, isFalse);
+    });
+
+    test('the tileset of a template is only added once', () {
+      final map = TiledMap.parseTmx(
+        readFixture('map_with_template_no_tileset.tmx'),
+        providers: [FixtureProvider()],
+      );
+      expect(map.tilesets, hasLength(2));
+    });
+
+    test('tilesets referenced from templates are resolved by path', () {
+      final map = TiledMap.parseTmx(
+        readFixture('map_nested.tmx'),
+        providers: [FixtureProvider()],
+      );
+      final tileset = map.tilesetByName('nested');
+      final template = (tileset.tiles.first.objectGroup! as ObjectGroup)
+          .objects
+          .single
+          .template!;
+      expect(template.tileSet!.source, equals('tilesets/nested_tileset.tsx'));
+      expect(map.tilesets, hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
# Description

#96 and #97 were merged into `spydon/tsx-provider` instead of `main`, and #72 was squash-merged before they landed on that branch, so their changes never reached `main`. This PR cherry-picks both commits on top of `main`.

Included:
- #96: Copy `version` and `type` from external tilesets when merging them.
- #97: Objects inherit every value they do not specify themselves from the object of their template, template `gid`s are translated to the tilesets of the map, and the tileset of a template is added to `TiledMap.tilesets` when the map does not contain it, like Tiled does. External tileset and template paths are now resolved relative to the map.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Re-lands #96 and #97 on `main`.

<!-- Links -->
[issue database]: https://github.com/flame-engine/tiled.dart/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org