### PR TITLE
fix: Add descriptive `toString` to `ParsingException` and test empty image layers

### DIFF
--- a/packages/tiled/lib/src/parser.dart
+++ b/packages/tiled/lib/src/parser.dart
@@ -10,6 +10,12 @@ class ParsingException implements Exception {
   final String reason;
 
   ParsingException(this.name, this.valueFound, this.reason);
+
+  @override
+  String toString() {
+    final found = valueFound == null ? '' : ', found: "$valueFound"';
+    return 'ParsingException: $reason (field: "$name"$found)';
+  }
 }
 
 class XmlParser extends Parser {

--- a/packages/tiled/test/image_layer_test.dart
+++ b/packages/tiled/test/image_layer_test.dart
@@ -64,4 +64,37 @@ void main() {
     expect(layer.image.width, equals(64));
     expect(layer.image.height, equals(32));
   });
+
+  test('parses an image layer without an image from xml', () {
+    final map = TiledMap.parseTmx('''
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal"
+ renderorder="right-down" width="1" height="1" tilewidth="16" tileheight="16"
+ infinite="0" nextlayerid="4" nextobjectid="1">
+ <imagelayer id="3" name="Image Layer 1"/>
+</map>
+''');
+    final layer = map.layerByName('Image Layer 1') as ImageLayer;
+    expect(layer.image.source, isNull);
+    expect(layer.image.width, isNull);
+    expect(layer.image.height, isNull);
+  });
+
+  test('parses an image layer without an image from json', () {
+    final map = TiledMap.parseJson('''
+{
+ "height":1, "width":1, "tileheight":16, "tilewidth":16,
+ "orientation":"orthogonal", "renderorder":"right-down", "version":"1.8",
+ "layers":[
+  {
+   "type":"imagelayer", "id":1, "name":"Background", "opacity":1,
+   "visible":true, "x":0, "y":0
+  }
+ ],
+ "tilesets":[]
+}
+''');
+    final layer = map.layerByName('Background') as ImageLayer;
+    expect(layer.image.source, isNull);
+  });
 }

--- a/packages/tiled/test/parser_test.dart
+++ b/packages/tiled/test/parser_test.dart
@@ -32,6 +32,49 @@ void main() {
     );
   });
 
+  group('ParsingException', () {
+    test('has a descriptive message', () {
+      final exception = ParsingException(
+        'image',
+        null,
+        'Required child missing',
+      );
+      expect(
+        exception.toString(),
+        equals('ParsingException: Required child missing (field: "image")'),
+      );
+    });
+
+    test('includes the found value in the message', () {
+      final exception = ParsingException('width', 'abc', 'Not an integer');
+      expect(
+        exception.toString(),
+        equals(
+          'ParsingException: Not an integer (field: "width", found: "abc")',
+        ),
+      );
+    });
+
+    test('is thrown with a descriptive message for a missing field', () {
+      const missingWidth = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" orientation="orthogonal" renderorder="right-down"
+ height="1" tilewidth="16" tileheight="16" infinite="0">
+</map>
+''';
+      expect(
+        () => TiledMap.parseTmx(missingWidth),
+        throwsA(
+          isA<ParsingException>().having(
+            (e) => e.toString(),
+            'toString',
+            contains('field: "width"'),
+          ),
+        ),
+      );
+    });
+  });
+
   group('Parser.parse returns a populated Map that', () {
     test('has its tileWidth = 32', () => expect(map.tileWidth, equals(32)));
     test('has its tileHeight = 32', () => expect(map.tileHeight, equals(32)));


### PR DESCRIPTION
# Description

Closes out the two remaining parts of #92.

The crash itself (an `<imagelayer>` without an `<image>` child throwing) was already fixed in #72, where the image layer parser started using `TiledImage.parseOrNull(parser) ?? const TiledImage()`. This PR adds regression tests for that case in both TMX and JSON so it stays fixed.

The second complaint in the issue was that the error surfaced as `Instance of 'ParsingException'`, which gives the user nothing to go on. `ParsingException` already carries `name`, `valueFound`, and `reason`, so this PR adds a `toString()` that uses them:

```
ParsingException: Required child missing (field: "image")
ParsingException: Not an integer (field: "width", found: "abc")
```

Tests cover the message format with and without a found value, and an end-to-end check that a map missing a required attribute throws a `ParsingException` naming that field.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #92

<!-- Links -->
[issue database]: https://github.com/flame-engine/tiled.dart/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org